### PR TITLE
Fix test, original author forgot to call function being tested: `mustMarkdownString`

### DIFF
--- a/renderers/markdown_test.go
+++ b/renderers/markdown_test.go
@@ -15,7 +15,7 @@ func TestRenderMarkdownWithHtml1(t *testing.T) {
 	require.Equal(t, "<p><div a=1><p><em>b</em></p>\n</div></p>\n", mustMarkdownString(`<div a=1 markdown="1">*b*</div>`))
 	require.Equal(t, "<p><div a=1><p><em>b</em></p>\n</div></p>\n", mustMarkdownString(`<div a=1 markdown='1'>*b*</div>`))
 	require.Equal(t, "<p><div a=1><p><em>b</em></p>\n</div></p>\n", mustMarkdownString(`<div a=1 markdown=1>*b*</div>`))
-	require.Equal(t, "<div a=1 markdown=1><p></div>", `<div a=1 markdown=1><p></div>`)
+	require.Equal(t, "<p><div a=1><p><p></div></p>\n</p>\n", mustMarkdownString(`<div a=1 markdown=1><p></div>`))
 }
 
 func TestRenderMarkdownWithHtml2(t *testing.T) {


### PR DESCRIPTION
## Checklist

- [X] I have read the contribution guidelines.
- [X] `make test` passes.
- [X] `make lint` passes.
- [X] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [X] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
