### PR TITLE
Remove leading and trailing hyphens from slugs to match jekyll behavior

### DIFF
--- a/utils/strings.go
+++ b/utils/strings.go
@@ -43,10 +43,15 @@ func SafeReplaceAllStringFunc(re *regexp.Regexp, src string, repl func(m string)
 }
 
 var nonAlphanumericSequenceMatcher = regexp.MustCompile(`[^[:alnum:]]+`)
+var leadingOrTrailingHyphenMatcher = regexp.MustCompile(`(^-|-$)`)
 
 // Slugify replaces each sequence of non-alphanumerics by a single hyphen
 func Slugify(s string) string {
-	return strings.ToLower(nonAlphanumericSequenceMatcher.ReplaceAllString(s, "-"))
+	slug := strings.ToLower(nonAlphanumericSequenceMatcher.ReplaceAllString(s, "-"))
+
+	// remove leading and trailing hyphen
+	slug = leadingOrTrailingHyphenMatcher.ReplaceAllString(slug, "")
+	return slug
 }
 
 // StringArrayToMap creates a map for use as a set.

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -35,6 +35,7 @@ func TestSlugify(t *testing.T) {
 	require.Equal(t, "ab-c", Slugify("ab-c"))
 	require.Equal(t, "ab-c", Slugify("ab()[]c"))
 	require.Equal(t, "ab123-cde-f-g", Slugify("ab123(cde)[]f.g"))
+	require.Equal(t, "abc", Slugify("abc?"))
 }
 
 func TestStringArrayToMap(t *testing.T) {


### PR DESCRIPTION
When I tried to use gojekyll with my blog, a post that had a question mark at the end had the wrong slug and therefore links` to the post broke. This was due to the fact that jekyll will strip leading and trailing hyphens after it replaces non-alphanumeric with hyphens. You can see this behavior here:

https://github.com/jekyll/jekyll/blob/646b4241669ac54247d8bf1ce3e4c616ac71d9fe/lib/jekyll/utils.rb#L219

To fix this, I added similar behavior to the Slugify function in gojekyll, and after that my site built with the correct routes.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
