### PR TITLE
Enable support for footnotes in markdown files to match jekyll behavior

### DIFF
--- a/renderers/markdown.go
+++ b/renderers/markdown.go
@@ -15,7 +15,8 @@ const blackfridayFlags = 0 |
 	blackfriday.Smartypants |
 	blackfriday.SmartypantsFractions |
 	blackfriday.SmartypantsDashes |
-	blackfriday.SmartypantsLatexDashes
+	blackfriday.SmartypantsLatexDashes |
+	blackfriday.FootnoteReturnLinks
 
 const blackfridayExtensions = 0 |
 	blackfriday.NoIntraEmphasis |
@@ -29,7 +30,8 @@ const blackfridayExtensions = 0 |
 	blackfriday.DefinitionLists |
 	blackfriday.NoEmptyLineBeforeBlock |
 	// added relative to commonExtensions
-	blackfriday.AutoHeadingIDs
+	blackfriday.AutoHeadingIDs |
+	blackfriday.Footnotes
 
 func renderMarkdown(md []byte) ([]byte, error) {
 	params := blackfriday.HTMLRendererParameters{


### PR DESCRIPTION
I noticed that my blog that the footnotes I had in my jekyll blog were no longer being generated from the markdown, and tracked it down to the flags that were being sent to blackfriday didn't enable footnotes. The footnote HTML generated by blackfriday doesn't 100% match what jekyll generates, but it's close enough that you can make it match with a single CSS rule.

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
