### PR TITLE
feat: Add permalink_timezone configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,9 +51,10 @@ type Config struct {
 	BaseURL     string
 
 	// Outputting
-	Permalink string
-	Timezone  string
-	Verbose   bool
+	Permalink         string
+	PermalinkTimezone string `yaml:"permalink_timezone,omitempty"`
+	Timezone          string
+	Verbose           bool
 	Defaults  []struct {
 		Scope struct {
 			Path string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Configuration
+---
+
+# Configuration
+
+This page details the configuration options available in Gojekyll's `_config.yml` file.
+
+## Permalink Timezone
+
+Gojekyll allows you to specify a timezone for generating dates in permalinks. This is useful for ensuring that your post URLs are consistent regardless of the server's local timezone.
+
+**Option:** `permalink_timezone`
+
+**Values:**
+- A valid IANA Time Zone Database name (e.g., "UTC", "America/New_York", "Europe/Berlin").
+- If left unset or empty, Gojekyll will use the server's local timezone. This matches the default behavior of Jekyll.
+
+**Example `_config.yml`:**
+
+```yaml
+# _config.yml
+title: My Awesome Blog
+permalink_timezone: "UTC" # Generates permalink dates in UTC
+```
+
+**Behavior:**
+
+- If `permalink_timezone` is set to a valid timezone, all date-based permalink variables (like `:year`, `:month`, `:day`) will be calculated based on that timezone.
+- If `permalink_timezone` is invalid (e.g., "Invalid/Timezone"), Gojekyll will log a warning and fall back to using the server's local timezone.
+- This setting affects how dates from your posts' front matter are interpreted for URL generation. For instance, a post dated `2023-01-01 02:00:00 +0500` (5 AM in a +0500 timezone) would use January 1st for permalink generation if `permalink_timezone` is "Asia/Kolkata" (UTC+5:30) or similar, but might use December 31st if `permalink_timezone` is "America/Los_Angeles" (UTC-8), depending on the exact date and time.
+
+By default, if you have posts with explicit timezone offsets in their `date` front matter, Gojekyll (like Jekyll) first converts this date to the site's effective timezone (either local or the one specified by `permalink_timezone`) before extracting year, month, and day for the permalink.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,3 +13,4 @@ This page exists mostly to dogfood site generation and themes, although it also 
 * [{{ p.name | remove: ".md" | capitalize }}]({{ p.url }})
 {% endif %}
 {% endfor %}
+* [Configuration](configuration.html)

--- a/pages/permalinks.go
+++ b/pages/permalinks.go
@@ -46,8 +46,19 @@ func (p *page) permalinkVariables() map[string]string {
 		name    = filepath.Base(root)
 		slug    = p.fm.String("slug", utils.Slugify(name))
 		// date      = p.fileModTime
-		date = p.PostDate().In(time.Local)
+		// date = p.PostDate().In(time.Local)
 	)
+	loc := time.Local
+	if tzName := p.site.Config.PermalinkTimezone; tzName != "" {
+		l, err := time.LoadLocation(tzName)
+		if err != nil {
+			// TODO: use a logger
+			fmt.Printf("Warning: Could not load timezone %q for permalink: %s. Using local time zone instead.\n", tzName, err)
+		} else {
+			loc = l
+		}
+	}
+	date := p.PostDate().In(loc)
 	vars := map[string]string{
 		"categories": strings.Join(p.Categories(), "/"),
 		"collection": p.fm.String("collection", ""),

--- a/pages/permalinks_test.go
+++ b/pages/permalinks_test.go
@@ -27,79 +27,184 @@ var staticTests = []pathTest{
 	{"base", "none", "/a/b/base.html"},
 }
 
-// Date-dependent tests will be generated dynamically based on the test date
-// This approach allows tests to pass in any time zone while we investigate the proper
-// time zone handling in permalinks. See: https://github.com/osteele/gojekyll/issues/63
-
 var collectionTests = []pathTest{
 	{"/a/b/c.d", "/prefix/:collection/post", "/prefix/c/post"},
 	{"/a/b/c.d", "/prefix:path/post", "/prefix/a/b/c/post"},
 }
 
-func TestExpandPermalinkPattern(t *testing.T) {
-	var (
-		s = siteFake{t, config.Default()}
-		d = map[string]interface{}{
-			"categories": "b a",
-		}
-	)
+// testPermalinkPatternHelper creates a page with a given config and computes its permalink.
+func testPermalinkPatternHelper(t *testing.T, cfg config.Config, pageDate time.Time, pattern, path string, data map[string]interface{}) (string, error) {
+	s := siteFake{t, cfg}
+	fm := frontmatter.Merge(data, FrontMatter{"permalink": pattern})
+	ext := filepath.Ext(path)
+	switch ext {
+	case ".md", ".markdown":
+		ext = ".html"
+	}
+	f := file{site: s, relPath: path, fm: fm, outputExt: ext}
+	p := page{file: f}
+	p.modTime = pageDate // This is used by p.PostDate() if no date in frontmatter
+	return p.computePermalink(p.permalinkVariables())
+}
 
-	// Create a test date in UTC - this is the reference date for all tests
-	testDate, err := time.Parse(time.RFC3339, "2006-02-03T15:04:05Z")
-	require.NoError(t, err)
-	
-	testPermalinkPattern := func(pattern, path string, data map[string]interface{}) (string, error) {
-		fm := frontmatter.Merge(data, FrontMatter{"permalink": pattern})
-		ext := filepath.Ext(path)
-		switch ext {
-		case ".md", ".markdown":
-			ext = ".html"
-		}
-		f := file{site: s, relPath: path, fm: fm, outputExt: ext}
-		p := page{file: f}
-		// Use the same test date that we use for generating expectations
-		p.modTime = testDate
-		return p.computePermalink(p.permalinkVariables())
+func TestExpandPermalinkPattern(t *testing.T) {
+	// Default frontmatter for most tests
+	defaultFM := map[string]interface{}{
+		"categories": "b a",
 	}
 
-	runTests := func(tests []pathTest) {
+	// Legacy test date
+	legacyTestDate, err := time.Parse(time.RFC3339, "2006-02-03T15:04:05Z")
+	require.NoError(t, err)
+
+	runLegacyTests := func(tests []pathTest, cfg config.Config, fm map[string]interface{}) {
 		for i, test := range tests {
-			t.Run(test.pattern, func(t *testing.T) {
-				p, err := testPermalinkPattern(test.pattern, test.path, d)
+			t.Run(fmt.Sprintf("legacy/%s", test.pattern), func(t *testing.T) {
+				p, err := testPermalinkPatternHelper(t, cfg, legacyTestDate, test.pattern, test.path, fm)
 				require.NoError(t, err)
 				require.Equalf(t, test.out, p, "%d: pattern=%s", i+1, test.pattern)
 			})
 		}
 	}
 
-	// Convert to local time to match the behavior in permalinks.go
-	// This is a workaround for the time zone dependency in the code.
-	// See https://github.com/osteele/gojekyll/issues/63 for the ongoing investigation
-	// about how Jekyll handles time zones and what approach we should standardize on.
-	localDate := testDate.In(time.Local)
-	
-	// Generate date-dependent tests with expected values based on the local date
-	dateTests := []pathTest{
-		{"base", "date", fmt.Sprintf("/a/b/%04d/%02d/%02d/base.html", localDate.Year(), localDate.Month(), localDate.Day())},
-		{"base", "pretty", fmt.Sprintf("/a/b/%04d/%02d/%02d/base/", localDate.Year(), localDate.Month(), localDate.Day())},
-		// For ordinal, we need to use the actual value that will be used in the code
-		// The code uses p.modTime.YearDay() directly, not the local date's year day
-		{"base", "ordinal", fmt.Sprintf("/a/b/%04d/%d/base.html", testDate.Year(), testDate.YearDay())},
+	defaultConfig := config.Default()
+
+	// Run non-date-dependent tests
+	runLegacyTests(staticTests, defaultConfig, defaultFM)
+
+	// Date-dependent tests (legacy behavior - uses local time)
+	localLegacyDate := legacyTestDate.In(time.Local)
+	legacyDateTests := []pathTest{
+		{"base", "date", fmt.Sprintf("/a/b/%04d/%02d/%02d/base.html", localLegacyDate.Year(), localLegacyDate.Month(), localLegacyDate.Day())},
+		{"base", "pretty", fmt.Sprintf("/a/b/%04d/%02d/%02d/base/", localLegacyDate.Year(), localLegacyDate.Month(), localLegacyDate.Day())},
+		{"base", "ordinal", fmt.Sprintf("/a/b/%04d/%d/base.html", legacyTestDate.Year(), legacyTestDate.YearDay())}, // ordinal always used UTC yearDay
 	}
-	
-	// Run the non-date-dependent tests
-	runTests(staticTests)
-	
-	// Run the date-dependent tests
-	runTests(dateTests)
+	runLegacyTests(legacyDateTests, defaultConfig, defaultFM)
 
-	s = siteFake{t, config.Default()}
-	d["collection"] = "c"
-	runTests(collectionTests)
+	// Collection tests (legacy)
+	collectionFM := map[string]interface{}{"categories": "b a", "collection": "c"}
+	runLegacyTests(collectionTests, defaultConfig, collectionFM)
 
-	t.Run("invalid template variable", func(t *testing.T) {
-		p, err := testPermalinkPattern("/:invalid", "/a/b/base.html", d)
+	t.Run("legacy/invalid template variable", func(t *testing.T) {
+		p, err := testPermalinkPatternHelper(t, defaultConfig, legacyTestDate, "/:invalid", "/a/b/base.html", defaultFM)
 		require.Error(t, err)
 		require.Zero(t, p)
 	})
+
+	// --- Timezone-aware tests ---
+	// Test date in UTC. Using a time that will fall on different dates in different timezones.
+	// Example: 2023-11-20 22:00:00 UTC is:
+	// - 2023-11-20 in America/Los_Angeles (PST, UTC-8)
+	// - 2023-11-21 in Europe/Berlin (CET, UTC+1)
+	permalinkTestDateUTC := time.Date(2023, 11, 20, 22, 0, 0, 0, time.UTC)
+
+	// Pre-load locations to ensure tests don't fail if system doesn't have them
+	locNewYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err, "Failed to load America/New_York timezone for testing")
+	// locLosAngeles, err := time.LoadLocation("America/Los_Angeles")
+	// require.NoError(t, err, "Failed to load America/Los_Angeles timezone for testing")
+
+	type permalinkTimezoneTestCase struct {
+		name              string
+		permalinkTimezone string
+		pageDate          time.Time
+		expectedYear      int
+		expectedMonth     time.Month
+		expectedDay       int
+	}
+
+	timezoneTestCases := []permalinkTimezoneTestCase{
+		{
+			name:              "No Timezone (Fallback to Local)",
+			permalinkTimezone: "", // Explicitly empty
+			pageDate:          permalinkTestDateUTC,
+			expectedYear:      permalinkTestDateUTC.In(time.Local).Year(),
+			expectedMonth:     permalinkTestDateUTC.In(time.Local).Month(),
+			expectedDay:       permalinkTestDateUTC.In(time.Local).Day(),
+		},
+		{
+			name:              "UTC Timezone",
+			permalinkTimezone: "UTC",
+			pageDate:          permalinkTestDateUTC,
+			expectedYear:      2023,
+			expectedMonth:     time.November,
+			expectedDay:       20, // 2023-11-20 22:00:00 UTC
+		},
+		{
+			name:              "America/New_York Timezone",
+			permalinkTimezone: "America/New_York",
+			pageDate:          permalinkTestDateUTC, // 2023-11-20 22:00:00 UTC is 2023-11-20 17:00:00 ET
+			expectedYear:      2023,
+			expectedMonth:     time.November,
+			expectedDay:       20,
+		},
+		{
+			name:              "America/New_York Timezone (Date change)",
+			permalinkTimezone: "America/New_York",
+			// 2023-11-21 02:00:00 UTC is 2023-11-20 21:00:00 ET (previous day in ET)
+			pageDate:          time.Date(2023, 11, 21, 2, 0, 0, 0, time.UTC),
+			expectedYear:      2023,
+			expectedMonth:     time.November,
+			expectedDay:       20,
+		},
+		{
+			name:              "Europe/Berlin Timezone (Date change)",
+			permalinkTimezone: "Europe/Berlin",
+			// 2023-11-20 22:00:00 UTC is 2023-11-20 23:00:00 CET (same day)
+			// Let's use a time that will be next day in Berlin
+			// 2023-11-20 23:30:00 UTC is 2023-11-21 00:30:00 CET
+			pageDate:          time.Date(2023, 11, 20, 23, 30, 0, 0, time.UTC),
+			expectedYear:      2023,
+			expectedMonth:     time.November,
+			expectedDay:       21,
+		},
+		{
+			name:              "Invalid Timezone (Fallback to Local)",
+			permalinkTimezone: "Invalid/Timezone",
+			pageDate:          permalinkTestDateUTC,
+			expectedYear:      permalinkTestDateUTC.In(time.Local).Year(),
+			expectedMonth:     permalinkTestDateUTC.In(time.Local).Month(),
+			expectedDay:       permalinkTestDateUTC.In(time.Local).Day(),
+		},
+	}
+
+	for _, tc := range timezoneTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.PermalinkTimezone = tc.permalinkTimezone
+			
+			// For these tests, we use a simple path and the "date" permalink style
+			// to make it easy to check the date components.
+			// Categories "testcat" and title "testpage" are arbitrary.
+			fm := map[string]interface{}{
+				"categories": "testcat",
+				"title":      "testpage", // title is used in date style if slug/name not present
+			}
+			path := "/testcat/testpage.md" // Path provides categories if not in FM.
+			pattern := "date"              // /:categories/:year/:month/:day/:title.html
+
+			actualPermalink, err := testPermalinkPatternHelper(t, cfg, tc.pageDate, pattern, path, fm)
+			require.NoError(t, err)
+
+			// Construct expected permalink
+			// Note: categories in permalink are slugified and ordered. "testcat" -> "testcat"
+			// title in permalink is slugified. "testpage" -> "testpage"
+			expectedPermalink := fmt.Sprintf("/testcat/%04d/%02d/%02d/testpage.html", tc.expectedYear, tc.expectedMonth, tc.expectedDay)
+			
+			// If categories were more complex, e.g., "b a", they'd be "/a/b/..."
+			// If title had spaces/special chars, it would be slugified.
+
+			require.Equal(t, expectedPermalink, actualPermalink)
+
+			// Additionally, test with "pretty" style to ensure trailing slash behavior is maintained
+			patternPretty := "pretty" // /:categories/:year/:month/:day/:title/
+			actualPermalinkPretty, err := testPermalinkPatternHelper(t, cfg, tc.pageDate, patternPretty, path, fm)
+			require.NoError(t, err)
+			expectedPermalinkPretty := fmt.Sprintf("/testcat/%04d/%02d/%02d/testpage/", tc.expectedYear, tc.expectedMonth, tc.expectedDay)
+			require.Equal(t, expectedPermalinkPretty, actualPermalinkPretty)
+
+		})
+	}
+	// Ensure that the NewYork location loaded correctly for subsequent tests if any
+	_ = locNewYork
 }


### PR DESCRIPTION
Implements #63.

This commit introduces a new configuration option `permalink_timezone` in `_config.yml`. This option allows you to specify an IANA timezone for generating dates in permalinks.

Key changes:
- Added `PermalinkTimezone` to `config.Config`.
- Modified `pages/permalinks.go` to use the specified timezone, falling back to `time.Local` if the option is not set or invalid.
- Updated tests in `pages/permalinks_test.go` to cover various timezone scenarios, including UTC, specific timezones like "America/New_York", and invalid timezone strings.
- Created new documentation file `docs/configuration.md` explaining the `permalink_timezone` option and its usage.
- Updated `docs/index.md` to link to the new configuration page.

If `permalink_timezone` is not set, the behavior remains consistent with Jekyll's default, which uses the local timezone of the machine running the build. If a timezone is specified (e.g., "UTC"), all permalink date components (:year, :month, :day) will be calculated based on that timezone. This provides you with more control over URL generation and helps ensure permalink consistency across different build environments.

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
