### PR TITLE
Fix linter errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: latest
-          args: --timeout=30m
+          args: --timeout=30m --issues-exit-code=1

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"crypto/md5" // nolint: gas
+	"crypto/md5"
 	"fmt"
 	"io"
 	"os"
@@ -45,10 +45,10 @@ func Disable() {
 // header and content are distinct parameters to relieve the caller from
 // having to concatenate them.
 func WithFile(header string, content string, fn func() (string, error)) (string, error) {
-	h := md5.New()             // nolint: gas
-	io.WriteString(h, content) // nolint: errcheck, gas
-	io.WriteString(h, "\n")    // nolint: errcheck, gas
-	io.WriteString(h, header)  // nolint: errcheck, gas
+	h := md5.New()
+	io.WriteString(h, content) // nolint: errcheck
+	io.WriteString(h, "\n")    // nolint: errcheck
+	io.WriteString(h, header)  // nolint: errcheck
 	sum := h.Sum(nil)
 
 	// don't use ioutil.TempDir, because we want this to last across invocations

--- a/commands/clean.go
+++ b/commands/clean.go
@@ -2,7 +2,7 @@ package commands
 
 import "github.com/osteele/gojekyll/site"
 
-var	clean = app.Command("clean", "Clean the site (removes site output) without building.")
+var clean = app.Command("clean", "Clean the site (removes site output) without building.")
 
 func cleanCommand(site *site.Site) error {
 	logger.label("Cleaner:", "Removing %s...", site.DestDir())

--- a/commands/routes.go
+++ b/commands/routes.go
@@ -14,7 +14,7 @@ func routesCommand(site *site.Site) error {
 	logger.label("Routes:", "")
 	var urls []string
 	for u, p := range site.Routes {
-		if !(*dynamicRoutes && p.IsStatic()) {
+		if !*dynamicRoutes || !p.IsStatic() {
 			urls = append(urls, u)
 		}
 	}

--- a/config/pathnames.go
+++ b/config/pathnames.go
@@ -20,13 +20,13 @@ func (c *Config) IsSASSPath(name string) bool {
 
 // markdownExtensions returns a set of markdown extensions, without the initial dots.
 func (c *Config) markdownExtensions() map[string]bool {
-	exts := strings.SplitN(c.MarkdownExt, `,`, -1)
+	exts := strings.Split(c.MarkdownExt, `,`)
 	return utils.StringArrayToMap(exts)
 }
 
 // MarkdownExtensions returns a list of markdown extensions, with dotsa.
 func (c *Config) MarkdownExtensions() []string {
-	exts := strings.SplitN(c.MarkdownExt, `,`, -1)
+	exts := strings.Split(c.MarkdownExt, `,`)
 	for i, k := range exts {
 		exts[i] = "." + k
 	}

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -184,7 +184,9 @@ func arrayToSentenceStringFilter(array []string, conjunction func(string) string
 
 func groupByExpFilter(array []map[string]interface{}, name string, expr expressions.Closure) ([]map[string]interface{}, error) {
 	rt := reflect.ValueOf(array)
-	if !(rt.Kind() != reflect.Array || rt.Kind() == reflect.Slice) {
+	// If input is a fixed-size array but not a slice, return nil to prevent errors
+	// This is a safety check to ensure we only operate on iterable collections
+	if rt.Kind() == reflect.Array && rt.Kind() != reflect.Slice {
 		return nil, nil
 	}
 	groups := map[interface{}][]interface{}{}
@@ -209,7 +211,9 @@ func groupByExpFilter(array []map[string]interface{}, name string, expr expressi
 
 func groupByFilter(array []map[string]interface{}, property string) []map[string]interface{} {
 	rt := reflect.ValueOf(array)
-	if !(rt.Kind() != reflect.Array || rt.Kind() == reflect.Slice) {
+	// If input is a fixed-size array but not a slice, return nil to prevent errors
+	// This is a safety check to ensure we only operate on iterable collections
+	if rt.Kind() == reflect.Array && rt.Kind() != reflect.Slice {
 		return nil
 	}
 	groups := map[interface{}][]interface{}{}

--- a/filters/smartify.go
+++ b/filters/smartify.go
@@ -32,8 +32,8 @@ var smartifyReplaceSpans = map[string]string{
 
 // replace these only if bounded by space or word boundaries
 var smartifyReplaceWords = map[string]string{
-// "---": "–",
-// "--":  "—",
+	// "---": "–",
+	// "--":  "—",
 }
 
 var smartifyReplacements map[string]string

--- a/frontmatter/read.go
+++ b/frontmatter/read.go
@@ -33,7 +33,7 @@ func Read(sourcePtr *[]byte, firstLine *int) (fm FrontMatter, err error) {
 		start  = 0
 	)
 	// Replace Windows line feeds. This allows the following regular expressions to work.
-	source = bytes.Replace(source, []byte("\r\n"), []byte("\n"), -1)
+	source = bytes.ReplaceAll(source, []byte("\r\n"), []byte("\n"))
 	if match := frontMatterMatcher.FindSubmatchIndex(source); match != nil {
 		start = match[1]
 		if err = yaml.Unmarshal(source[match[2]:match[3]], &fm); err != nil {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	err := commands.ParseAndRun(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err) // nolint: gas
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/pages/permalinks_test.go
+++ b/pages/permalinks_test.go
@@ -47,7 +47,7 @@ func TestExpandPermalinkPattern(t *testing.T) {
 	// Create a test date in UTC - this is the reference date for all tests
 	testDate, err := time.Parse(time.RFC3339, "2006-02-03T15:04:05Z")
 	require.NoError(t, err)
-	
+
 	testPermalinkPattern := func(pattern, path string, data map[string]interface{}) (string, error) {
 		fm := frontmatter.Merge(data, FrontMatter{"permalink": pattern})
 		ext := filepath.Ext(path)
@@ -77,7 +77,7 @@ func TestExpandPermalinkPattern(t *testing.T) {
 	// See https://github.com/osteele/gojekyll/issues/63 for the ongoing investigation
 	// about how Jekyll handles time zones and what approach we should standardize on.
 	localDate := testDate.In(time.Local)
-	
+
 	// Generate date-dependent tests with expected values based on the local date
 	dateTests := []pathTest{
 		{"base", "date", fmt.Sprintf("/a/b/%04d/%02d/%02d/base.html", localDate.Year(), localDate.Month(), localDate.Day())},
@@ -86,10 +86,10 @@ func TestExpandPermalinkPattern(t *testing.T) {
 		// The code uses p.modTime.YearDay() directly, not the local date's year day
 		{"base", "ordinal", fmt.Sprintf("/a/b/%04d/%d/base.html", testDate.Year(), testDate.YearDay())},
 	}
-	
+
 	// Run the non-date-dependent tests
 	runTests(staticTests)
-	
+
 	// Run the date-dependent tests
 	runTests(dateTests)
 

--- a/pages/static_file.go
+++ b/pages/static_file.go
@@ -18,7 +18,7 @@ func (p *StaticFile) Write(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close() // nolint: errcheck, gas
+	defer in.Close() // nolint: errcheck
 	_, err = io.Copy(w, in)
 	return err
 }

--- a/plugins/github_metadata.go
+++ b/plugins/github_metadata.go
@@ -125,7 +125,7 @@ func getCurrentRepo(c *config.Config) (string, error) {
 	if s, ok := c.String("repository"); ok {
 		return s, nil
 	}
-	cmd := exec.Command("git", "remote", "-v") // nolint: gas
+	cmd := exec.Command("git", "remote", "-v")
 	cmd.Dir = c.SourceDir()
 	out, err := cmd.Output()
 	if err != nil {
@@ -139,7 +139,7 @@ func getCurrentRepo(c *config.Config) (string, error) {
 }
 
 func getBuildRevision(dir string) string {
-	cmd := exec.Command("git", "rev-parse", "HEAD") // nolint: gas
+	cmd := exec.Command("git", "rev-parse", "HEAD")
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {

--- a/plugins/paginate.go
+++ b/plugins/paginate.go
@@ -27,7 +27,7 @@ func createPaginator(n, perPage int, posts []Page) map[string]interface{} {
 	pageCount := (len(posts) + perPage - 1) / perPage
 	paginatePath := "/blog/page:num/"
 	pagePath := func(n int) string {
-		return strings.Replace(paginatePath, ":num", fmt.Sprint(n), -1)
+		return strings.ReplaceAll(paginatePath, ":num", fmt.Sprint(n))
 	}
 	m := map[string]interface{}{
 		"page":               n,

--- a/renderers/layouts.go
+++ b/renderers/layouts.go
@@ -37,7 +37,7 @@ func (p *Manager) ApplyLayout(name string, content []byte, vars liquid.Bindings)
 func (p *Manager) FindLayout(base string, fmp *map[string]interface{}) (tpl *liquid.Template, err error) {
 	// not cached, but the time here is negligible
 	exts := []string{"", ".html"}
-	for _, ext := range strings.SplitN(p.cfg.MarkdownExt, `,`, -1) {
+	for _, ext := range strings.Split(p.cfg.MarkdownExt, `,`) {
 		exts = append(exts, "."+ext)
 	}
 	var (

--- a/renderers/sass.go
+++ b/renderers/sass.go
@@ -2,7 +2,7 @@ package renderers
 
 import (
 	"bytes"
-	"crypto/md5" // nolint: gas
+	"crypto/md5"
 	"fmt"
 	"io"
 	"os"
@@ -29,7 +29,7 @@ func (p *Manager) copySASSFileIncludes() error {
 	if err := p.makeSASSTempDir(); err != nil {
 		return err
 	}
-	h := md5.New() // nolint: gas
+	h := md5.New()
 	if p.ThemeDir != "" {
 		if err := p.copySASSFiles(filepath.Join(p.ThemeDir, sassDirName), p.sassTempDir, h); err != nil {
 			return err
@@ -74,7 +74,9 @@ func (p *Manager) copySASSFiles(src, dst string, h io.Writer) error {
 			return err
 		}
 		defer in.Close() // nolint: errcheck
-		fmt.Fprintf(h, "--- sass file: %s ---\n", rel)
+		if _, err = fmt.Fprintf(h, "--- sass file: %s ---\n", rel); err != nil {
+			return err
+		}
 		if _, err = io.Copy(h, in); err != nil {
 			return err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -66,7 +66,10 @@ func (s *Server) handler(rw http.ResponseWriter, r *http.Request) {
 		p, found = site.Routes["/404.html"]
 	}
 	if !found {
-		fmt.Fprintf(rw, "404 page not found: %s\n", urlpath) // nolint: gas
+		_, err := fmt.Fprintf(rw, "404 page not found: %s\n", urlpath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing HTTP response: %s", err)
+		}
 		return
 	}
 	mimeType := mime.TypeByExtension(p.OutputExt())

--- a/site/theme.go
+++ b/site/theme.go
@@ -17,7 +17,7 @@ func (s *Site) findTheme() error {
 	if err != nil {
 		log.Fatal("bundle is not in your PATH", err)
 	}
-	cmd := exec.Command(exe, "show", s.cfg.Theme) // nolint: gas
+	cmd := exec.Command(exe, "show", s.cfg.Theme)
 	cmd.Dir = s.AbsDir()
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/site/write.go
+++ b/site/write.go
@@ -66,7 +66,6 @@ func (s *Site) WriteDoc(d Document) error {
 		// FIXME render the page, just don't write it
 		return nil
 	}
-	// nolint: gas
 	if err := os.MkdirAll(filepath.Dir(to), 0755); err != nil {
 		return err
 	}

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -73,10 +73,7 @@ func TrimExt(name string) string {
 // URLPathClean removes internal // etc. Unlike path.Clean, it
 // leaves the final "/" intact.
 func URLPathClean(url string) string {
-	finalSlash := false
-	if strings.HasSuffix(url, "/") && len(url) > 1 {
-		finalSlash = true
-	}
+	finalSlash := strings.HasSuffix(url, "/") && len(url) > 1
 	cleaned := path.Clean(url)
 	if finalSlash && !strings.HasSuffix(cleaned, "/") {
 		cleaned += "/"

--- a/utils/ioutil.go
+++ b/utils/ioutil.go
@@ -11,7 +11,6 @@ import (
 // CopyFileContents copies the file contents from src to dst.
 // It's not atomic and doesn't copy permissions or metadata.
 func CopyFileContents(dst, src string, perm os.FileMode) error {
-	// nolint: gas
 	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
 		return err
 	}
@@ -19,13 +18,13 @@ func CopyFileContents(dst, src string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close() // nolint: errcheck, gas
+	defer in.Close() // nolint: errcheck
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
 	}
 	if _, err = io.Copy(out, in); err != nil {
-		_ = os.Remove(dst) // nolint: gas
+		_ = os.Remove(dst)
 		return err
 	}
 	return out.Close()

--- a/utils/string_set.go
+++ b/utils/string_set.go
@@ -21,5 +21,5 @@ func (ss StringSet) AddStrings(a []string) {
 
 // Contains returns true iff the string is in the set.
 func (ss StringSet) Contains(s string) bool {
-		return ss[s]
+	return ss[s]
 }

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ func init() {
 	if BuildDate != "" {
 		bd, err := time.Parse("2006-01-02T15:04:05-0700", BuildDate)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "invalid BuildDate", BuildDate) // nolint: gas
+			fmt.Fprintln(os.Stderr, "invalid BuildDate", BuildDate)
 		} else {
 			BuildTime = bd.In(time.UTC)
 		}


### PR DESCRIPTION
This commit:
- Fix errcheck errors by handling return values from fmt.Fprintf
- Fix De Morgan's law conditional statements
- Replace strings.SplitN with strings.Split where appropriate
- Replace bytes.Replace with bytes.ReplaceAll
- Replace strings.Replace with strings.ReplaceAll
- Merge conditional assignment into variable declaration
- Remove obsolete 'gas' linter directives

Fixes #68

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
