### PR TITLE
feat: implement Jekyll-compatible permalink handling for pages vs posts

### DIFF
--- a/docs/PERMALINKS.md
+++ b/docs/PERMALINKS.md
@@ -1,0 +1,88 @@
+# Permalink Handling in Gojekyll
+
+This document explains how gojekyll handles permalinks and the important distinctions between different document types. This behavior matches Jekyll's permalink handling for compatibility.
+
+## Overview
+
+Gojekyll supports Jekyll's permalink configuration system, allowing URLs to be customized via:
+1. Front matter `permalink` field (highest priority)
+2. Global `permalink` configuration in `_config.yml`
+3. Default permalink pattern
+
+## Document Type Distinctions
+
+### Critical Concept: Posts vs Pages vs Collections
+
+Jekyll (and `gojekyll`) treats different document types differently when processing permalink patterns. This distinction is intentional and required for Jekyll compatibility.
+
+#### Posts (collection == "posts")
+- **Full permalink pattern support**: All placeholders are honored
+- **Available placeholders**: `:year`, `:month`, `:day`, `:categories`, `:title`, etc.
+- **Example**: `permalink: pretty` → `/:categories/:year/:month/:day/:title/`
+- **Result**: `/blog/2024/03/15/my-post/`
+
+#### Pages (regular pages, not in any collection)
+- **Date and category placeholders are IGNORED**
+- **Available placeholders**: `:path`, `:basename`, `:output_ext`, `:title`
+- **Example**: `permalink: pretty` → `/:title/` (dates/categories removed)
+- **Result**: `/about/` (not `/2024/03/15/about/`)
+
+#### Collection Documents (non-post collections)
+- **Same as pages**: Date and category placeholders are ignored
+- **Additional placeholder**: `:collection`
+- **Example**: `authors` collection with `permalink: pretty` → `/:title/`
+
+## Why This Distinction Exists
+
+According to Jekyll's official documentation:
+> "Pages and collections (excluding posts and drafts) don't have time and categories, so aspects of the permalink style are ignored for the output."
+
+This makes sense because:
+- **Posts** are inherently date-based content (blog posts, news articles)
+- **Pages** are timeless content (About, Contact, Services pages)
+- **Collections** can be either, but default to timeless
+
+## Examples
+
+### Config: `permalink: pretty`
+
+| Document Type | Source File | Jekyll URL | Pattern After Processing |
+|--------------|-------------|------------|-------------------------|
+| Post | `_posts/2024-03-15-hello.md` | `/2024/03/15/hello/` | `/:year/:month/:day/:title/` |
+| Page | `about.md` | `/about/` | `/:title/` |
+| Collection | `_authors/john.md` | `/john/` | `/:title/` |
+
+### Config: `permalink: date`
+
+| Document Type | Source File | Jekyll URL | Pattern After Processing |
+|--------------|-------------|------------|-------------------------|
+| Post | `_posts/2024-03-15-hello.md` | `/2024/03/15/hello.html` | `/:year/:month/:day/:title:output_ext` |
+| Page | `about.md` | `/about.html` | `/:title:output_ext` |
+
+## Common Pitfalls
+
+1. **Expecting dates in page URLs**: Pages don't have dates, even if you set `date` in front matter
+2. **Categories on pages**: Categories are ignored for pages, only work for posts
+3. **Front matter permalink in global config**: Built-in styles (pretty, date, etc.) only work in `_config.yml`, not in front matter
+
+## Testing
+
+When testing permalink behavior:
+1. Test posts separately from pages
+2. Test with and without categories
+3. Test all built-in permalink styles
+4. Test custom patterns with various placeholders
+
+## Maintenance Notes
+
+⚠️ **DO NOT REMOVE** the distinction between posts and pages in permalink processing. It's required for Jekyll compatibility.
+
+## References
+The Jekyll documentation at https://jekyllrb.com/docs/permalinks/.
+
+## Related Files
+
+- `pages/permalinks.go` - Core permalink processing logic
+- `pages/permalinks_test.go` - Comprehensive tests
+- `config/default.go` - Default permalink configuration
+- `collection/collection.go` - Collection-specific permalink handling

--- a/pages/permalinks.go
+++ b/pages/permalinks.go
@@ -66,10 +66,32 @@ func (p *page) permalinkVariables() map[string]string {
 }
 
 func (p *page) computePermalink(vars map[string]string) (src string, err error) {
-	pattern := p.fm.String("permalink", DefaultPermalinkPattern)
+	// First check for permalink in front matter
+	var pattern string
+	if permalink, hasFrontMatterPermalink := p.fm["permalink"]; hasFrontMatterPermalink {
+		pattern = fmt.Sprintf("%v", permalink)
+	} else {
+		// If no front matter permalink, check global config
+		if globalPermalink := p.site.Config().Permalink; globalPermalink != "" {
+			pattern = globalPermalink
+		} else {
+			pattern = DefaultPermalinkPattern
+		}
+	}
+
+	// Apply built-in permalink styles
 	if pat, found := PermalinkStyles[pattern]; found {
 		pattern = pat
 	}
+
+	// Jekyll Compatibility: Remove date/category placeholders for non-posts
+	// Posts use the full permalink pattern, while pages and other collections
+	// ignore date and category placeholders. This distinction is required for
+	// Jekyll compatibility. See docs/PERMALINKS.md for detailed explanation.
+	if !p.IsPost() {
+		pattern = removePostOnlyPlaceholders(pattern)
+	}
+
 	templateVariables := p.permalinkVariables()
 	s, err := utils.SafeReplaceAllStringFunc(templateVariableMatcher, pattern, func(m string) (string, error) {
 		varname := m[1:]
@@ -83,6 +105,38 @@ func (p *page) computePermalink(vars map[string]string) (src string, err error) 
 		return "", err
 	}
 	return utils.URLPathClean("/" + s), nil
+}
+
+// removePostOnlyPlaceholders removes date and category placeholders from permalink patterns
+// for non-post documents (pages and non-post collections).
+// This matches Jekyll's behavior where these placeholders are ignored for non-posts.
+func removePostOnlyPlaceholders(pattern string) string {
+	// Remove category placeholder
+	pattern = strings.ReplaceAll(pattern, ":categories/", "")
+	pattern = strings.ReplaceAll(pattern, "/:categories", "")
+
+	// Remove date-related placeholders
+	datePatterns := []string{
+		":year/", ":month/", ":day/", ":hour/", ":minute/", ":second/",
+		":i_month/", ":i_day/", ":short_year/", ":y_day/",
+		"/:year", "/:month", "/:day", "/:hour", "/:minute", "/:second",
+		"/:i_month", "/:i_day", "/:short_year", "/:y_day",
+	}
+	for _, dp := range datePatterns {
+		pattern = strings.ReplaceAll(pattern, dp, "")
+	}
+
+	// Clean up any double slashes that might result
+	for strings.Contains(pattern, "//") {
+		pattern = strings.ReplaceAll(pattern, "//", "/")
+	}
+
+	// Ensure pattern starts with /
+	if !strings.HasPrefix(pattern, "/") {
+		pattern = "/" + pattern
+	}
+
+	return pattern
 }
 
 func (p *page) setPermalink() (err error) {

--- a/pages/permalinks_test.go
+++ b/pages/permalinks_test.go
@@ -23,8 +23,8 @@ var staticTests = []pathTest{
 	{"/a/b/base.html", "/prefix/:path/post", "/prefix/a/b/base/post"},
 	{"/a/b/base.html", "/prefix/:title", "/prefix/base"},
 	{"/a/b/base.html", "/prefix/:slug", "/prefix/base"},
-	{"base", "/:categories/:name:output_ext", "/a/b/base"},
-	{"base", "none", "/a/b/base.html"},
+	{"base", "/:categories/:name:output_ext", "/base"}, // categories ignored for non-posts
+	{"base", "none", "/base.html"},                     // categories ignored for non-posts
 }
 
 // Date-dependent tests will be generated dynamically based on the test date
@@ -72,19 +72,12 @@ func TestExpandPermalinkPattern(t *testing.T) {
 		}
 	}
 
-	// Convert to local time to match the behavior in permalinks.go
-	// This is a workaround for the time zone dependency in the code.
-	// See https://github.com/osteele/gojekyll/issues/63 for the ongoing investigation
-	// about how Jekyll handles time zones and what approach we should standardize on.
-	localDate := testDate.In(time.Local)
-
-	// Generate date-dependent tests with expected values based on the local date
+	// Generate date-dependent tests with expected values
+	// NOTE: These are pages (not posts), so date/category placeholders are ignored per Jekyll behavior
 	dateTests := []pathTest{
-		{"base", "date", fmt.Sprintf("/a/b/%04d/%02d/%02d/base.html", localDate.Year(), localDate.Month(), localDate.Day())},
-		{"base", "pretty", fmt.Sprintf("/a/b/%04d/%02d/%02d/base/", localDate.Year(), localDate.Month(), localDate.Day())},
-		// For ordinal, we need to use the actual value that will be used in the code
-		// The code uses p.modTime.YearDay() directly, not the local date's year day
-		{"base", "ordinal", fmt.Sprintf("/a/b/%04d/%d/base.html", testDate.Year(), testDate.YearDay())},
+		{"base", "date", "/base.html"},    // dates/categories ignored for non-posts
+		{"base", "pretty", "/base/"},      // dates/categories ignored for non-posts
+		{"base", "ordinal", "/base.html"}, // dates/categories ignored for non-posts
 	}
 
 	// Run the non-date-dependent tests
@@ -102,4 +95,145 @@ func TestExpandPermalinkPattern(t *testing.T) {
 		require.Error(t, err)
 		require.Zero(t, p)
 	})
+}
+
+func TestPostPermalinkPatterns(t *testing.T) {
+	// Test that posts correctly use date and category placeholders
+	var (
+		s = siteFake{t, config.Default()}
+		d = map[string]interface{}{
+			"categories": "blog tech",
+			"collection": "posts", // Mark as post
+			"title":      "My Post",
+		}
+	)
+
+	testDate, err := time.Parse(time.RFC3339, "2006-02-03T15:04:05Z")
+	require.NoError(t, err)
+	localDate := testDate.In(time.Local)
+
+	testPermalinkPattern := func(pattern, path string, data map[string]interface{}) (string, error) {
+		fm := frontmatter.Merge(data, FrontMatter{"permalink": pattern})
+		ext := filepath.Ext(path)
+		switch ext {
+		case ".md", ".markdown":
+			ext = ".html"
+		}
+		f := file{site: s, relPath: path, fm: fm, outputExt: ext}
+		p := page{file: f}
+		p.modTime = testDate
+		return p.computePermalink(p.permalinkVariables())
+	}
+
+	tests := []struct {
+		pattern  string
+		expected string
+	}{
+		{"date", fmt.Sprintf("/blog/tech/%04d/%02d/%02d/my-post.html", localDate.Year(), localDate.Month(), localDate.Day())},
+		{"pretty", fmt.Sprintf("/blog/tech/%04d/%02d/%02d/my-post/", localDate.Year(), localDate.Month(), localDate.Day())},
+		{"ordinal", fmt.Sprintf("/blog/tech/%04d/%d/my-post.html", testDate.Year(), testDate.YearDay())},
+		{"none", "/blog/tech/my-post.html"},
+		{"/:categories/:year/:month/:title/", fmt.Sprintf("/blog/tech/%04d/%02d/my-post/", localDate.Year(), localDate.Month())},
+	}
+
+	for _, test := range tests {
+		t.Run(test.pattern, func(t *testing.T) {
+			p, err := testPermalinkPattern(test.pattern, "/_posts/2006-02-03-my-post.md", d)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, p)
+		})
+	}
+}
+
+func TestGlobalPermalinkConfiguration(t *testing.T) {
+	testDate, err := time.Parse(time.RFC3339, "2006-02-03T15:04:05Z")
+	require.NoError(t, err)
+	localDate := testDate.In(time.Local)
+
+	tests := []struct {
+		name            string
+		globalPermalink string
+		pagePath        string
+		frontMatter     map[string]interface{}
+		expected        string
+	}{
+		{
+			name:            "pretty permalink for regular page",
+			globalPermalink: "pretty",
+			pagePath:        "/bread.html",
+			frontMatter:     map[string]interface{}{"title": "Bread Page"},
+			expected:        "/bread-page/", // Jekyll ignores dates/categories for pages
+		},
+		{
+			name:            "date permalink for regular page",
+			globalPermalink: "date",
+			pagePath:        "/about.html",
+			frontMatter:     map[string]interface{}{"title": "About"},
+			expected:        "/about.html", // Date placeholders ignored for pages
+		},
+		{
+			name:            "none permalink for regular page",
+			globalPermalink: "none",
+			pagePath:        "/contact.html",
+			frontMatter:     map[string]interface{}{"title": "Contact"},
+			expected:        "/contact.html",
+		},
+		{
+			name:            "pretty permalink for post",
+			globalPermalink: "pretty",
+			pagePath:        "/_posts/2006-02-03-hello.html",
+			frontMatter:     map[string]interface{}{"title": "Hello World", "collection": "posts"},
+			expected:        fmt.Sprintf("/%04d/%02d/%02d/hello-world/", localDate.Year(), localDate.Month(), localDate.Day()),
+		},
+		{
+			name:            "date permalink for post",
+			globalPermalink: "date",
+			pagePath:        "/_posts/2006-02-03-hello.html",
+			frontMatter:     map[string]interface{}{"title": "Hello World", "collection": "posts"},
+			expected:        fmt.Sprintf("/%04d/%02d/%02d/hello-world.html", localDate.Year(), localDate.Month(), localDate.Day()),
+		},
+		{
+			name:            "front matter overrides global",
+			globalPermalink: "pretty",
+			pagePath:        "/special.html",
+			frontMatter:     map[string]interface{}{"permalink": "/custom/path/"},
+			expected:        "/custom/path/",
+		},
+		{
+			name:            "no global permalink uses default",
+			globalPermalink: "",
+			pagePath:        "/default.html",
+			frontMatter:     map[string]interface{}{"title": "Default"},
+			expected:        "/default.html",
+		},
+		{
+			name:            "collection document with pretty permalink",
+			globalPermalink: "pretty",
+			pagePath:        "/_authors/john.html",
+			frontMatter:     map[string]interface{}{"title": "John Doe", "collection": "authors"},
+			expected:        "/john-doe/", // Date/categories ignored for non-post collections
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Permalink = tt.globalPermalink
+			s := siteFake{t, cfg}
+
+			p := page{
+				file: file{
+					site:      s,
+					relPath:   tt.pagePath,
+					outputExt: ".html",
+					fm:        tt.frontMatter,
+					modTime:   testDate,
+				},
+			}
+
+			err := p.setPermalink()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, p.URL())
+		})
+	}
 }


### PR DESCRIPTION
Fixes #61 - Support page directories with pretty permalinks

This change implements Jekyll's behavior where pages and non-post collections ignore date and category placeholders in permalink patterns.

Key changes:
- Pages now respect global permalink configuration from _config.yml
- Date/category placeholders are removed for non-post documents (Jekyll compatibility)
- Front matter permalinks continue to override global configuration
- Added comprehensive tests and documentation

Behavior:
- Posts: Full permalink pattern with dates/categories (e.g., /2024/03/15/title/)
- Pages: Simplified pattern without dates/categories (e.g., /title/)
- Collections (non-posts): Also use simplified patterns

This matches Jekyll's documented behavior: "Pages and collections (excluding posts and drafts) don't have time and categories, so aspects of the permalink style are ignored for the output."

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
