### PR TITLE
fix: handle URLs without trailing slashes for directory-style permalinks

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -2,6 +2,7 @@ package site
 
 import (
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/osteele/gojekyll/collection"
@@ -213,6 +214,10 @@ func (s *Site) URLPage(urlpath string) (p Document, found bool) {
 	if !found {
 		// Serve extensionless URL `/some-url` from file `/some-url.html`
 		p, found = s.Routes[filepath.Join(urlpath+".html")]
+	}
+	if !found && !strings.HasSuffix(urlpath, "/") {
+		// Try with trailing slash for directory-style permalinks
+		p, found = s.Routes[urlpath+"/"]
 	}
 	return
 }

--- a/site/urlpage_test.go
+++ b/site/urlpage_test.go
@@ -1,0 +1,62 @@
+package site
+
+import (
+	"io"
+	"testing"
+
+	"github.com/osteele/gojekyll/config"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDocument implements Document interface for testing
+type mockDocument struct {
+	url       string
+	published bool
+}
+
+func (d *mockDocument) URL() string         { return d.url }
+func (d *mockDocument) Source() string      { return "" }
+func (d *mockDocument) OutputExt() string   { return ".html" }
+func (d *mockDocument) Published() bool     { return d.published }
+func (d *mockDocument) IsStatic() bool      { return false }
+func (d *mockDocument) Write(io.Writer) error { return nil }
+func (d *mockDocument) Reload() error       { return nil }
+
+func TestURLPageTrailingSlash(t *testing.T) {
+	s := New(config.Flags{})
+	s.Routes = make(map[string]Document)
+	
+	// Test trailing slash handling for directory-style permalinks
+	aboutPage := &mockDocument{url: "/about/", published: true}
+	s.Routes["/about/"] = aboutPage
+	
+	// Should find page with exact match
+	p, found := s.URLPage("/about/")
+	require.True(t, found, "Should find page with exact match including trailing slash")
+	require.Equal(t, aboutPage, p)
+	
+	// Should find page when trailing slash is missing
+	p, found = s.URLPage("/about")
+	require.True(t, found, "Should find page without trailing slash when registered with trailing slash")
+	require.Equal(t, aboutPage, p)
+	
+	// Test index.html fallback
+	indexPage := &mockDocument{url: "/posts/index.html", published: true}
+	s.Routes["/posts/index.html"] = indexPage
+	
+	p, found = s.URLPage("/posts")
+	require.True(t, found, "Should find index.html when accessing directory")
+	require.Equal(t, indexPage, p)
+	
+	// Test .html extension fallback
+	contactPage := &mockDocument{url: "/contact.html", published: true}
+	s.Routes["/contact.html"] = contactPage
+	
+	p, found = s.URLPage("/contact")
+	require.True(t, found, "Should find .html file without extension")
+	require.Equal(t, contactPage, p)
+	
+	// Test non-existent page
+	_, found = s.URLPage("/nonexistent")
+	require.False(t, found, "Should not find non-existent page")
+}


### PR DESCRIPTION
When pages have permalinks ending with a slash (e.g., /about/), the server now correctly serves them when accessed without the trailing slash (e.g., /about).

This fixes issue #52 where non-root URLs resulted in 404 errors when accessed without trailing slashes.

- Modified URLPage() to check for routes with trailing slashes when exact match fails
- Added comprehensive tests for URL routing with various permalink styles
- Verified fix with sample Jekyll site

Fixes #52

## Checklist

- [x] I have read the contribution guidelines.
- [x] `make test` passes.
- [x] `make lint` passes.
- [x] New and changed code is covered by tests.
- [x] Performance improvements include benchmarks.
- [x] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
