### PR TITLE
Rationalize logging throughout the codebase

### DIFF
--- a/commands/benchmark.go
+++ b/commands/benchmark.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/montanaflynn/stats"
@@ -28,10 +27,10 @@ func benchmarkCommand() (err error) {
 		dur := time.Since(sampleStart).Seconds()
 		samples = append(samples, dur)
 		quiet = true
-		fmt.Printf("Run #%d; %.1fs elapsed\n", i+1, time.Since(commandStartTime).Seconds())
+		log.Printf("Run #%d; %.1fs elapsed\n", i+1, time.Since(commandStartTime).Seconds())
 	}
 	median, _ := stats.Median(samples)
 	stddev, _ := stats.StandardDeviationSample(samples)
-	fmt.Printf("%d samples @ %.2fs ± %.2fs\n", len(samples), median, stddev)
+	log.Printf("%d samples @ %.2fs ± %.2fs\n", len(samples), median, stddev)
 	return nil
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-	"os"
 	"time"
 
 	"github.com/osteele/gojekyll/site"
@@ -20,15 +18,15 @@ func init() {
 func buildCommand(site *site.Site) error {
 	watch := site.Config().Watch
 
-	logger.path("Destination:", site.DestDir())
-	logger.label("Generating...", "")
+	bannerLog.path("Destination:", site.DestDir())
+	bannerLog.label("Generating...", "")
 	count, err := site.Write()
 	switch {
 	case err == nil:
 		elapsed := time.Since(commandStartTime)
-		logger.label("", "wrote %d files in %.2fs.", count, elapsed.Seconds())
+		bannerLog.label("", "wrote %d files in %.2fs.", count, elapsed.Seconds())
 	case watch:
-		fmt.Fprintln(os.Stderr, err)
+		log.Error(err.Error())
 	default:
 		return err
 	}
@@ -41,12 +39,12 @@ func buildCommand(site *site.Site) error {
 		if err != nil {
 			return err
 		}
-		logger.label("Auto-regeneration:", "enabled for %q", site.SourceDir())
+		bannerLog.label("Auto-regeneration:", "enabled for %q", site.SourceDir())
 		for event := range events {
-			fmt.Print(event)
+			log.Printf("%s", event)
 		}
 	} else {
-		logger.label("Auto-regeneration:", "disabled. Use --watch to enable.")
+		bannerLog.label("Auto-regeneration:", "disabled. Use --watch to enable.")
 	}
 	return nil
 }

--- a/commands/clean.go
+++ b/commands/clean.go
@@ -5,6 +5,6 @@ import "github.com/osteele/gojekyll/site"
 var clean = app.Command("clean", "Clean the site (removes site output) without building.")
 
 func cleanCommand(site *site.Site) error {
-	logger.label("Cleaner:", "Removing %s...", site.DestDir())
+	bannerLog.label("Cleaner:", "Removing %s...", site.DestDir())
 	return site.Clean()
 }

--- a/commands/logging.go
+++ b/commands/logging.go
@@ -1,25 +1,24 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/utils"
 )
 
-type bannerLogger struct{ labelWidth int }
+// log is the logger instance used by commands
+var log = logger.Default()
 
-var logger = bannerLogger{}
+type bannerLogger struct{}
+
+var bannerLog = bannerLogger{}
 
 func (l *bannerLogger) Info(a ...interface{}) {
-	fmt.Println(a...)
+	log.Println(a...)
 }
 
 func (l *bannerLogger) label(label string, msg string, a ...interface{}) {
-	if len(label) > l.labelWidth {
-		l.labelWidth = len(label)
-	}
 	if !quiet {
-		fmt.Printf("%s %s\n", utils.LeftPad(label, l.labelWidth), fmt.Sprintf(msg, a...))
+		log.Label(label, msg, a...)
 	}
 }
 

--- a/commands/plugins.go
+++ b/commands/plugins.go
@@ -1,19 +1,17 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/osteele/gojekyll/plugins"
 )
 
 var pluginsApp = app.Command("plugins", "List emulated plugins")
 
 func pluginsCommand() error {
-	logger.label("Plugins:", "")
+	bannerLog.label("Plugins:", "")
 	for _, name := range plugins.Names() {
-		fmt.Printf("  %s\n", name)
+		log.Printf("  %s\n", name)
 	}
-	fmt.Println("\nhttps://github.com/osteele/gojekyll/blob/master/docs/plugins.md describes plugin implementation status.")
-	fmt.Println("(This may not accurately describe your installation, if you are running an older version of gojekyll.)")
+	log.Println("\nhttps://github.com/osteele/gojekyll/blob/master/docs/plugins.md describes plugin implementation status.")
+	log.Println("(This may not accurately describe your installation, if you are running an older version of gojekyll.)")
 	return nil
 }

--- a/commands/render.go
+++ b/commands/render.go
@@ -15,9 +15,9 @@ func renderCommand(site *site.Site) error {
 	if err != nil {
 		return err
 	}
-	logger.path("Render:", filepath.Join(site.SourceDir(), p.Source()))
+	bannerLog.path("Render:", filepath.Join(site.SourceDir(), p.Source()))
 	//nolint:govet
-	logger.label("URL:", p.URL())
-	logger.label("Content:", "")
+	bannerLog.label("URL:", p.URL())
+	bannerLog.label("Content:", "")
 	return site.WriteDocument(os.Stdout, p)
 }

--- a/commands/routes.go
+++ b/commands/routes.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/osteele/gojekyll/site"
@@ -11,7 +10,7 @@ var routes = app.Command("routes", "Display site permalinks and associated files
 var dynamicRoutes = routes.Flag("dynamic", "Only show routes to non-static files").Bool()
 
 func routesCommand(site *site.Site) error {
-	logger.label("Routes:", "")
+	bannerLog.label("Routes:", "")
 	var urls []string
 	for u, p := range site.Routes {
 		if !*dynamicRoutes || !p.IsStatic() {
@@ -21,7 +20,7 @@ func routesCommand(site *site.Site) error {
 	sort.Strings(urls)
 	for _, u := range urls {
 		filename := site.Routes[u].Source()
-		fmt.Printf("  %s -> %s\n", u, filename)
+		log.Printf("  %s -> %s\n", u, filename)
 	}
 	return nil
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -32,6 +32,9 @@ func ParseAndRun(args []string) error {
 
 func run(cmd string) error { // nolint: gocyclo
 	// dispatcher gets to ignore cyclo threshold ^
+	// Set quiet mode on logger
+	log.SetQuiet(quiet)
+
 	if profile || cmd == benchmark.FullCommand() {
 		defer setupProfiling()()
 	}
@@ -51,7 +54,7 @@ func run(cmd string) error { // nolint: gocyclo
 	// loading the site produced an error.
 	if *versionFlag {
 		//nolint:govet
-		logger.label("Version:", version.Version)
+		bannerLog.label("Version:", version.Version)
 	}
 	if err != nil {
 		return err
@@ -85,18 +88,18 @@ func loadSite(source string, flags config.Flags) (*site.Site, error) {
 	}
 	const configurationFileLabel = "Configuration file:"
 	if cf := site.Config().ConfigFile; cf != "" {
-		logger.path(configurationFileLabel, cf)
+		bannerLog.path(configurationFileLabel, cf)
 	} else {
-		logger.label(configurationFileLabel, "none")
+		bannerLog.label(configurationFileLabel, "none")
 	}
-	logger.path("Source:", site.SourceDir())
+	bannerLog.path("Source:", site.SourceDir())
 	err = site.Read()
 	return site, err
 }
 
 func setupProfiling() func() {
 	profilePath := "gojekyll.prof"
-	logger.label("Profiling...", "")
+	bannerLog.label("Profiling...", "")
 	f, err := os.Create(profilePath)
 	app.FatalIfError(err, "")
 	err = pprof.StartCPUProfile(f)
@@ -105,6 +108,6 @@ func setupProfiling() func() {
 		pprof.StopCPUProfile()
 		err = f.Close()
 		app.FatalIfError(err, "")
-		logger.Info("Wrote", profilePath)
+		bannerLog.Info("Wrote", profilePath)
 	}
 }

--- a/commands/serve.go
+++ b/commands/serve.go
@@ -16,6 +16,6 @@ func serveCommand(site *site.Site) error {
 	server := server.Server{Site: site}
 	return server.Run(*open, func(label, value string) {
 		//nolint:govet
-		logger.label(label, value)
+		bannerLog.label(label, value)
 	})
 }

--- a/commands/variables.go
+++ b/commands/variables.go
@@ -34,7 +34,7 @@ func variablesCommand(site *site.Site) (err error) {
 	}
 	data = liquid.FromDrop(data)
 	bytesToStrings(data)
-	logger.label("Variables:", "")
+	bannerLog.label("Variables:", "")
 	_, err = pp.Print(data)
 	return err
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/osteele/gojekyll/version"
 )
 
@@ -13,6 +11,6 @@ func versionCommand() error {
 	if !version.BuildTime.IsZero() {
 		d = version.BuildTime.Format(" (Build time: 2006-01-02T15:04)")
 	}
-	fmt.Printf("gojekyll version %s%s\n", version.Version, d)
+	log.Printf("gojekyll version %s%s\n", version.Version, d)
 	return nil
 }

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -15,6 +15,7 @@ import (
 	sass "github.com/bep/godartsass/v2"
 	blackfriday "github.com/danog/blackfriday/v2"
 	"github.com/osteele/gojekyll/config"
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/utils"
 	"github.com/osteele/liquid"
 	"github.com/osteele/liquid/evaluator"
@@ -153,9 +154,10 @@ func requireNonEmptyArray(fn func([]interface{}) interface{}) func([]interface{}
 
 func unimplementedFilter(name string) func(value interface{}) interface{} {
 	warned := false
+	log := logger.Default()
 	return func(value interface{}) interface{} {
 		if !warned {
-			fmt.Println("warning: unimplemented filter:", name)
+			log.Warn("unimplemented filter: %s", name)
 			warned = true
 		}
 		return value

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,221 @@
+// Package logger provides a centralized logging facility for gojekyll.
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// Level represents the severity of a log message.
+type Level int
+
+const (
+	// DebugLevel for detailed debugging information
+	DebugLevel Level = iota
+	// InfoLevel for general informational messages
+	InfoLevel
+	// WarnLevel for warning messages
+	WarnLevel
+	// ErrorLevel for error messages
+	ErrorLevel
+)
+
+// Logger is the interface for logging operations.
+type Logger struct {
+	level      Level
+	quiet      bool
+	out        io.Writer
+	err        io.Writer
+	labelWidth int
+	mu         sync.Mutex
+}
+
+var defaultLogger = &Logger{
+	level: InfoLevel,
+	quiet: false,
+	out:   os.Stdout,
+	err:   os.Stderr,
+}
+
+// New creates a new Logger instance.
+func New() *Logger {
+	return &Logger{
+		level: InfoLevel,
+		quiet: false,
+		out:   os.Stdout,
+		err:   os.Stderr,
+	}
+}
+
+// Default returns the default logger instance.
+func Default() *Logger {
+	return defaultLogger
+}
+
+// SetLevel sets the minimum log level.
+func (l *Logger) SetLevel(level Level) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.level = level
+}
+
+// SetQuiet enables or disables quiet mode.
+// In quiet mode, Info and Debug messages are suppressed.
+func (l *Logger) SetQuiet(quiet bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.quiet = quiet
+}
+
+// SetOutput sets the output destination for Info and Debug messages.
+func (l *Logger) SetOutput(w io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.out = w
+}
+
+// SetErrorOutput sets the output destination for Warning and Error messages.
+func (l *Logger) SetErrorOutput(w io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.err = w
+}
+
+// Debug logs a debug message.
+func (l *Logger) Debug(msg string, args ...interface{}) {
+	l.log(DebugLevel, msg, args...)
+}
+
+// Info logs an informational message.
+func (l *Logger) Info(msg string, args ...interface{}) {
+	l.log(InfoLevel, msg, args...)
+}
+
+// Warn logs a warning message.
+func (l *Logger) Warn(msg string, args ...interface{}) {
+	l.log(WarnLevel, msg, args...)
+}
+
+// Error logs an error message.
+func (l *Logger) Error(msg string, args ...interface{}) {
+	l.log(ErrorLevel, msg, args...)
+}
+
+// Label logs a message with a label prefix (used for formatted output).
+// The label is left-padded to maintain alignment.
+func (l *Logger) Label(label string, msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.quiet {
+		return
+	}
+
+	if len(label) > l.labelWidth {
+		l.labelWidth = len(label)
+	}
+
+	formatted := fmt.Sprintf(msg, args...)
+	fmt.Fprintf(l.out, "%*s %s\n", l.labelWidth, label, formatted)
+}
+
+// Println logs arguments separated by spaces with a newline.
+func (l *Logger) Println(args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.quiet {
+		return
+	}
+
+	fmt.Fprintln(l.out, args...)
+}
+
+// Printf logs a formatted message.
+func (l *Logger) Printf(format string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.quiet {
+		return
+	}
+
+	fmt.Fprintf(l.out, format, args...)
+}
+
+func (l *Logger) log(level Level, msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Check if we should suppress this message
+	if level < l.level {
+		return
+	}
+
+	if l.quiet && (level == InfoLevel || level == DebugLevel) {
+		return
+	}
+
+	// Choose output destination
+	out := l.out
+	if level >= WarnLevel {
+		out = l.err
+	}
+
+	// Format and write the message
+	formatted := fmt.Sprintf(msg, args...)
+	if len(args) > 0 {
+		fmt.Fprintln(out, formatted)
+	} else {
+		fmt.Fprintln(out, msg)
+	}
+}
+
+// Package-level convenience functions that use the default logger
+
+// SetLevel sets the minimum log level on the default logger.
+func SetLevel(level Level) {
+	defaultLogger.SetLevel(level)
+}
+
+// SetQuiet enables or disables quiet mode on the default logger.
+func SetQuiet(quiet bool) {
+	defaultLogger.SetQuiet(quiet)
+}
+
+// Debug logs a debug message using the default logger.
+func Debug(msg string, args ...interface{}) {
+	defaultLogger.Debug(msg, args...)
+}
+
+// Info logs an informational message using the default logger.
+func Info(msg string, args ...interface{}) {
+	defaultLogger.Info(msg, args...)
+}
+
+// Warn logs a warning message using the default logger.
+func Warn(msg string, args ...interface{}) {
+	defaultLogger.Warn(msg, args...)
+}
+
+// Error logs an error message using the default logger.
+func Error(msg string, args ...interface{}) {
+	defaultLogger.Error(msg, args...)
+}
+
+// Label logs a message with a label prefix using the default logger.
+func Label(label string, msg string, args ...interface{}) {
+	defaultLogger.Label(label, msg, args...)
+}
+
+// Println logs arguments using the default logger.
+func Println(args ...interface{}) {
+	defaultLogger.Println(args...)
+}
+
+// Printf logs a formatted message using the default logger.
+func Printf(format string, args ...interface{}) {
+	defaultLogger.Printf(format, args...)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,124 @@
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	l := New()
+	l.SetOutput(&outBuf)
+	l.SetErrorOutput(&errBuf)
+
+	// Test Info level logging
+	l.Info("test info message")
+	if !strings.Contains(outBuf.String(), "test info message") {
+		t.Errorf("Info message not logged correctly: %s", outBuf.String())
+	}
+
+	// Test Warning level logging
+	outBuf.Reset()
+	errBuf.Reset()
+	l.Warn("test warning message")
+	if !strings.Contains(errBuf.String(), "test warning message") {
+		t.Errorf("Warning message not logged correctly: %s", errBuf.String())
+	}
+
+	// Test Error level logging
+	errBuf.Reset()
+	l.Error("test error message")
+	if !strings.Contains(errBuf.String(), "test error message") {
+		t.Errorf("Error message not logged correctly: %s", errBuf.String())
+	}
+}
+
+func TestQuietMode(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	l := New()
+	l.SetOutput(&outBuf)
+	l.SetErrorOutput(&errBuf)
+	l.SetQuiet(true)
+
+	// Info and Debug should be suppressed
+	l.Info("test info")
+	l.Debug("test debug")
+	if outBuf.Len() > 0 {
+		t.Errorf("Info/Debug messages should be suppressed in quiet mode, got: %s", outBuf.String())
+	}
+
+	// Warnings and Errors should still appear
+	l.Warn("test warning")
+	l.Error("test error")
+	if !strings.Contains(errBuf.String(), "test warning") || !strings.Contains(errBuf.String(), "test error") {
+		t.Errorf("Warning/Error messages should appear in quiet mode, got: %s", errBuf.String())
+	}
+}
+
+func TestLogLevel(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	l := New()
+	l.SetOutput(&outBuf)
+	l.SetErrorOutput(&errBuf)
+	l.SetLevel(WarnLevel)
+
+	// Info and Debug should be suppressed
+	l.Info("test info")
+	l.Debug("test debug")
+	if outBuf.Len() > 0 {
+		t.Errorf("Messages below log level should be suppressed, got: %s", outBuf.String())
+	}
+
+	// Warnings and Errors should appear
+	l.Warn("test warning")
+	l.Error("test error")
+	if !strings.Contains(errBuf.String(), "test warning") || !strings.Contains(errBuf.String(), "test error") {
+		t.Errorf("Messages at or above log level should appear, got: %s", errBuf.String())
+	}
+}
+
+func TestLabel(t *testing.T) {
+	var outBuf bytes.Buffer
+	l := New()
+	l.SetOutput(&outBuf)
+
+	l.Label("create", "/path/to/file")
+	output := outBuf.String()
+	if !strings.Contains(output, "create") || !strings.Contains(output, "/path/to/file") {
+		t.Errorf("Label output incorrect: %s", output)
+	}
+
+	// Test label width alignment
+	outBuf.Reset()
+	l.Label("rm", "/another/file")
+	output = outBuf.String()
+	// The label should be padded to match previous width
+	if !strings.Contains(output, "rm") || !strings.Contains(output, "/another/file") {
+		t.Errorf("Label output incorrect: %s", output)
+	}
+}
+
+func TestPrintf(t *testing.T) {
+	var outBuf bytes.Buffer
+	l := New()
+	l.SetOutput(&outBuf)
+
+	l.Printf("test %s %d", "message", 42)
+	output := outBuf.String()
+	if !strings.Contains(output, "test message 42") {
+		t.Errorf("Printf output incorrect: %s", output)
+	}
+}
+
+func TestPrintln(t *testing.T) {
+	var outBuf bytes.Buffer
+	l := New()
+	l.SetOutput(&outBuf)
+
+	l.Println("test", "message")
+	output := outBuf.String()
+	if !strings.Contains(output, "test message") {
+		t.Errorf("Println output incorrect: %s", output)
+	}
+}

--- a/pages/permalinks.go
+++ b/pages/permalinks.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/utils"
 )
 
@@ -52,8 +53,8 @@ func (p *page) permalinkVariables() map[string]string {
 	if tzName := p.site.Config().PermalinkTimezone; tzName != "" {
 		l, err := time.LoadLocation(tzName)
 		if err != nil {
-			// TODO: use a logger
-			fmt.Printf("Warning: Could not load timezone %q for permalink: %s. Using local time zone instead.\n", tzName, err)
+			log := logger.Default()
+			log.Warn("Could not load timezone %q for permalink: %s. Using local time zone instead.", tzName, err)
 		} else {
 			loc = l
 		}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -6,12 +6,12 @@
 package plugins
 
 import (
-	"fmt"
 	"regexp"
 	"sort"
 
 	"github.com/kyokomi/emoji"
 	"github.com/osteele/gojekyll/config"
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/pages"
 	"github.com/osteele/gojekyll/utils"
 	"github.com/osteele/liquid"
@@ -49,13 +49,14 @@ func Lookup(name string) (Plugin, bool) {
 
 // Install installs a registered plugin.
 func Install(names []string, site Site) error {
+	log := logger.Default()
 	for _, name := range names {
 		if p, found := directory[name]; found {
 			if err := p.AfterInitSite(site); err != nil {
 				return err
 			}
 		} else {
-			fmt.Printf("warning: gojekyll does not emulate the %s plugin.\n", name)
+			log.Warn("gojekyll does not emulate the %s plugin.", name)
 		}
 	}
 	return nil

--- a/renderers/sass.go
+++ b/renderers/sass.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/osteele/gojekyll/cache"
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/utils"
 	"github.com/tdewolff/minify"
 	"github.com/tdewolff/minify/css"
@@ -46,7 +47,8 @@ func (p *Manager) makeSASSTempDir() error {
 	if p.sassTempDir == "" {
 		dir, err := os.MkdirTemp(os.TempDir(), "_sass")
 		if p.cfg.Verbose {
-			fmt.Println("create", dir)
+			log := logger.Default()
+			log.Info("create %s", dir)
 		}
 		if err != nil {
 			return err
@@ -57,8 +59,9 @@ func (p *Manager) makeSASSTempDir() error {
 }
 
 func (p *Manager) copySASSFiles(src, dst string, h io.Writer) error {
+	log := logger.Default()
 	if p.cfg.Verbose {
-		fmt.Printf("copy sass directory %s to %s\n", src, dst)
+		log.Info("copy sass directory %s to %s", src, dst)
 	}
 	err := filepath.Walk(src, func(from string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
@@ -67,7 +70,7 @@ func (p *Manager) copySASSFiles(src, dst string, h io.Writer) error {
 		rel := utils.MustRel(src, from)
 		to := filepath.Join(dst, strings.TrimPrefix(rel, "_"))
 		if p.cfg.Verbose {
-			fmt.Printf("copy sass file %s to %s\n", src, to)
+			log.Info("copy sass file %s to %s", src, to)
 		}
 		in, err := os.Open(from)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -46,7 +46,7 @@ func (s *Server) Run(open bool, logger func(label, value string)) error {
 	logger("Server running...", "press ctrl-c to stop.")
 	if open {
 		if err := browser.OpenURL("http://" + address); err != nil {
-			fmt.Println("Error opening page:", err)
+			fmt.Fprintln(os.Stderr, "Error opening page:", err)
 		}
 	}
 	return <-c

--- a/server/watcher.go
+++ b/server/watcher.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"fmt"
-	"os"
 	"time"
 
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/site"
 )
 
@@ -49,16 +49,17 @@ func (s *Server) reload(change site.FilesEvent) {
 	defer s.m.Unlock()
 
 	// similar code to site.WatchRebuild
-	fmt.Printf("Re-reading: %v...", change)
+	log := logger.Default()
+	log.Printf("Re-reading: %v...", change)
 	start := time.Now()
 	site, err := s.Site.Reloaded(change.Paths)
 	if err != nil {
-		fmt.Println()
-		fmt.Fprintln(os.Stderr, err.Error())
+		log.Println()
+		log.Error(err.Error())
 		s.lr.Alert(fmt.Sprintf("Error reading site configuration: %s", err))
 		return
 	}
 	s.Site = site
 	s.Site.SetAbsoluteURL("")
-	fmt.Printf("done (%.2fs)\n", time.Since(start).Seconds())
+	log.Printf("done (%.2fs)\n", time.Since(start).Seconds())
 }

--- a/site/build.go
+++ b/site/build.go
@@ -1,20 +1,21 @@
 package site
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/utils"
 )
 
 // Clean the destination. Remove files that aren't in keep_files, and resulting empty directories.
 func (s *Site) Clean() error {
 	// TODO PERF when called as part of build, keep files that will be re-generated
+	log := logger.Default()
 	removeFiles := func(filename string, info os.FileInfo, err error) error {
 		if s.cfg.Verbose {
-			fmt.Println("rm", filename)
+			log.Info("rm %s", filename)
 		}
 		switch {
 		case err != nil && os.IsNotExist(err):
@@ -39,9 +40,10 @@ func (s *Site) Clean() error {
 }
 
 func (s *Site) setTimeZone() error {
+	log := logger.Default()
 	if tz := s.cfg.Timezone; tz != "" {
 		if _, err := time.LoadLocation(tz); err != nil {
-			fmt.Fprintf(os.Stderr, "%s; using local time zone\n", err)
+			log.Error("%s; using local time zone", err)
 		} else if err := os.Setenv("TZ", tz); err != nil {
 			return err
 		}

--- a/site/rebuild.go
+++ b/site/rebuild.go
@@ -2,9 +2,9 @@ package site
 
 import (
 	"fmt"
-	"os"
 	"time"
 
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/utils"
 )
 
@@ -44,12 +44,13 @@ func (s *Site) Reloaded(paths []string) (*Site, error) {
 
 func (s *Site) processFilesEvent(fileset FilesEvent, messages chan<- interface{}) *Site {
 	// similar code to server.reload
+	log := logger.Default()
 	messages <- fmt.Sprintf("Regenerating: %s...", fileset)
 	start := time.Now()
 	r, count, err := s.rebuild(fileset.Paths)
 	if err != nil {
-		fmt.Println()
-		fmt.Fprintln(os.Stderr, err)
+		log.Println()
+		log.Error(err.Error())
 		return s
 	}
 	elapsed := time.Since(start)

--- a/site/write.go
+++ b/site/write.go
@@ -2,11 +2,11 @@ package site
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/plugins"
 	"github.com/osteele/gojekyll/utils"
 )
@@ -60,7 +60,8 @@ func (s *Site) WriteDoc(d Document) error {
 	}
 	to := filepath.Join(s.DestDir(), rel)
 	if s.cfg.Verbose {
-		fmt.Println("create", to, "from", d.Source())
+		log := logger.Default()
+		log.Info("create %s from %s", to, d.Source())
 	}
 	if s.cfg.DryRun {
 		// FIXME render the page, just don't write it

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/osteele/gojekyll/config"
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/liquid"
 	"github.com/osteele/liquid/render"
 )
@@ -33,9 +34,10 @@ type tagContext struct {
 // time it's rendered, and otherwise does nothing.
 func CreateUnimplementedTag() liquid.Renderer {
 	warned := false
+	log := logger.Default()
 	return func(rc render.Context) (string, error) {
 		if !warned {
-			fmt.Printf("The %q tag has not been implemented. It is being ignored.\n", rc.TagName())
+			log.Warn("The %q tag has not been implemented. It is being ignored.", rc.TagName())
 			warned = true
 		}
 		return "", nil


### PR DESCRIPTION
This commit addresses issue #35 by replacing scattered fmt.Printf statements with a centralized logging package.

Changes:
- Created new logger package with proper log levels (Debug, Info, Warning, Error)
- Implemented support for quiet mode
- Added formatted label output for consistent CLI display
- Replaced all fmt.Printf/Println calls with appropriate logger calls
- Integrated quiet flag with the logger throughout commands package
- Updated all packages: commands, server, plugins, filters, renderers, site, tags, and pages

The new logging system provides better organization and maintainability while preserving the existing user-facing behavior.

Fixes #35

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
