### PR TITLE
feat: implement table of contents (TOC) support for issue #62

### DIFF
--- a/renderers/markdown_toc_test.go
+++ b/renderers/markdown_toc_test.go
@@ -113,7 +113,7 @@ func TestTOCGeneration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := processTOC([]byte(tt.html))
+			result, err := processTOC([]byte(tt.html), nil)
 			if err != nil {
 				t.Fatalf("Error processing HTML: %v", err)
 			}
@@ -171,4 +171,148 @@ func TestMarkdownTOCIntegration(t *testing.T) {
 
 func containsString(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+func TestTOCLevelsFiltering(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		opts     *TOCOptions
+		expected string
+	}{
+		{
+			name: "Filter to H2-H3 only",
+			html: `<h1 id="title">Title</h1>
+<p>{:toc}</p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>
+<h4 id="subsubsection1">SubSubsection 1</h4>
+<h2 id="section2">Section 2</h2>`,
+			opts: &TOCOptions{MinLevel: 2, MaxLevel: 3, UseJekyllHTML: false},
+			expected: `<h1 id="title">Title</h1>
+<p><div class="toc"><ul class="section-nav"><li><a href="#section1">Section 1</a><ul><li><a href="#subsection1">Subsection 1</a></li></ul></li><li><a href="#section2">Section 2</a></li></ul></div></p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>
+<h4 id="subsubsection1">SubSubsection 1</h4>
+<h2 id="section2">Section 2</h2>`,
+		},
+		{
+			name: "Filter to H1-H2 only",
+			html: `<h1 id="title">Title</h1>
+<p>{:toc}</p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>
+<h2 id="section2">Section 2</h2>`,
+			opts: &TOCOptions{MinLevel: 1, MaxLevel: 2, UseJekyllHTML: false},
+			expected: `<h1 id="title">Title</h1>
+<p><div class="toc"><ul class="section-nav"><li><a href="#title">Title</a><ul><li><a href="#section1">Section 1</a></li><li><a href="#section2">Section 2</a></li></ul></li></ul></div></p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>
+<h2 id="section2">Section 2</h2>`,
+		},
+		{
+			name: "Filter removes all headings",
+			html: `<h1 id="title">Title</h1>
+<p>{:toc}</p>
+<h2 id="section1">Section 1</h2>`,
+			opts: &TOCOptions{MinLevel: 3, MaxLevel: 4, UseJekyllHTML: false},
+			expected: `<h1 id="title">Title</h1>
+<p><div class="toc"><ul class="section-nav"><li>No headings found</li></ul></div></p>
+<h2 id="section1">Section 1</h2>`,
+		},
+		{
+			name: "Jekyll-compatible HTML structure",
+			html: `<h1 id="title">Title</h1>
+<p>{:toc}</p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>`,
+			opts: &TOCOptions{MinLevel: 1, MaxLevel: 6, UseJekyllHTML: true},
+			expected: `<h1 id="title">Title</h1>
+<p><ul id="markdown-toc"><li><a href="#title">Title</a><ul><li><a href="#section1">Section 1</a><ul><li><a href="#subsection1">Subsection 1</a></li></ul></li></ul></li></ul></p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>`,
+		},
+		{
+			name: "Jekyll HTML with toc_levels filtering",
+			html: `<h1 id="title">Title</h1>
+<p>{:toc}</p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>
+<h2 id="section2">Section 2</h2>`,
+			opts: &TOCOptions{MinLevel: 2, MaxLevel: 2, UseJekyllHTML: true},
+			expected: `<h1 id="title">Title</h1>
+<p><ul id="markdown-toc"><li><a href="#section1">Section 1</a></li><li><a href="#section2">Section 2</a></li></ul></p>
+<h2 id="section1">Section 1</h2>
+<h3 id="subsection1">Subsection 1</h3>
+<h2 id="section2">Section 2</h2>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := processTOC([]byte(tt.html), tt.opts)
+			if err != nil {
+				t.Fatalf("Error processing HTML: %v", err)
+			}
+
+			if string(result) != tt.expected {
+				t.Errorf("Expected:\n%s\n\nGot:\n%s", tt.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestTOCLevelsParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       interface{}
+		expectMin   int
+		expectMax   int
+	}{
+		{
+			name:      "String range 1..6",
+			input:     "1..6",
+			expectMin: 1,
+			expectMax: 6,
+		},
+		{
+			name:      "String range 2..3",
+			input:     "2..3",
+			expectMin: 2,
+			expectMax: 3,
+		},
+		{
+			name:      "String range 2..4",
+			input:     "2..4",
+			expectMin: 2,
+			expectMax: 4,
+		},
+		{
+			name:      "Array format",
+			input:     []interface{}{2, 3, 4},
+			expectMin: 2,
+			expectMax: 4,
+		},
+		{
+			name:      "Single level array",
+			input:     []interface{}{3},
+			expectMin: 3,
+			expectMax: 3,
+		},
+		{
+			name:      "Invalid input returns defaults",
+			input:     "invalid",
+			expectMin: 1,
+			expectMax: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max := parseTOCLevels(tt.input)
+			if min != tt.expectMin || max != tt.expectMax {
+				t.Errorf("Expected (%d, %d), got (%d, %d)", tt.expectMin, tt.expectMax, min, max)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Adds support for Kramdown-compatible table of contents generation using {:toc} and {::toc} markers. This addresses issue #62.

Features:
- Support for {:toc} and {::toc} markers to insert TOC
- Automatic generation of nested TOC from document headings
- Support for {:.no_toc} attribute to exclude specific headings
- Proper heading ID preservation for anchor links
- Compatible with existing markdown rendering pipeline

Implementation details:
- Uses placeholder replacement to avoid markdown processing conflicts
- Extracts headings before rendering and matches with generated IDs
- Generates properly nested HTML lists with anchor links
- Includes comprehensive test coverage

Testing:
- Added TestTOCGeneration for basic TOC functionality
- Added TestTOCExcludesNoToc for exclusion behavior
- Added TestTOCNesting for nested heading levels
- All existing tests continue to pass

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
