### PR TITLE
Fix build error from PR #71 template issue

### DIFF
--- a/pages/page.go
+++ b/pages/page.go
@@ -185,7 +185,8 @@ func (p *page) Write(w io.Writer) error {
 	defer p.m.RUnlock()
 	cn := p.content
 	lo, ok := p.fm["layout"].(string)
-	if ok && lo != "" {
+	// Jekyll compatibility: "none" and "null" are special values that disable layout
+	if ok && lo != "" && lo != "none" && lo != "null" {
 		rm := p.site.RendererManager()
 		b, err := rm.ApplyLayout(lo, []byte(cn), p.TemplateContext())
 		if err != nil {

--- a/pages/page_test.go
+++ b/pages/page_test.go
@@ -53,6 +53,24 @@ func TestPage_Write(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "testdata/liquid_error.md", pe.Path())
 	})
+
+	t.Run("layout: none", func(t *testing.T) {
+		p := requirePageFromFile(t, "page_with_none_layout.md")
+		buf := new(bytes.Buffer)
+		require.NoError(t, p.Write(buf))
+		require.Contains(t, buf.String(), "Page content without layout")
+		// Should not try to apply a layout named "none"
+		require.NotContains(t, buf.String(), "no template for none")
+	})
+
+	t.Run("layout: null", func(t *testing.T) {
+		p := requirePageFromFile(t, "page_with_null_layout.md")
+		buf := new(bytes.Buffer)
+		require.NoError(t, p.Write(buf))
+		require.Contains(t, buf.String(), "Page content with null layout")
+		// Should not try to apply a layout named "null"
+		require.NotContains(t, buf.String(), "no template for null")
+	})
 }
 
 func fakePageFromFile(t *testing.T, file string) (Document, error) {

--- a/pages/testdata/page_with_none_layout.md
+++ b/pages/testdata/page_with_none_layout.md
@@ -1,0 +1,4 @@
+---
+layout: none
+---
+Page content without layout

--- a/pages/testdata/page_with_null_layout.md
+++ b/pages/testdata/page_with_null_layout.md
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+Page content with null layout

--- a/plugins/default_layout.go
+++ b/plugins/default_layout.go
@@ -28,6 +28,7 @@ func (p jekyllDefaultLayout) layoutNames(s Site) map[string]string {
 
 func (p jekyllDefaultLayout) PostInitPage(s Site, pg Page) error {
 	fm := pg.FrontMatter()
+	// Don't override if layout is explicitly set (including "none" or "null")
 	if fm["layout"] != nil {
 		return nil
 	}


### PR DESCRIPTION
Fixes issue where pages with `layout: none` or `layout: null` in front matter would cause "no template for none" error. These are special Jekyll values that explicitly disable layout rendering.

Changes:
- Modified page.Write() to skip layout application for "none" and "null"
- Updated comment in default_layout plugin for clarity
- Added test cases for both layout values

This fixes the build error reported in GitHub issue where user's site broke with "no template for none" error.

## Checklist

- [ ] I have read the contribution guidelines.
- [ ] `make test` passes.
- [ ] `make lint` passes.
- [ ] New and changed code is covered by tests.
- [ ] Performance improvements include benchmarks.
- [ ] Changes match the *documented* (not just the *implemented*) behavior of Jekyll.
