### PR TITLE
Fix multiple critical bugs in file watching, dry-run, and live-reload

### DIFF
--- a/renderers/sass.go
+++ b/renderers/sass.go
@@ -26,7 +26,13 @@ const sassDirName = "_sass"
 func (p *Manager) copySASSFileIncludes() error {
 	// TODO delete the temp directory when done?
 	// TODO use libsass.ImportsOption instead?
-	// FIXME this doesn't delete stale css files
+	// Clean up any existing temp directory to remove stale files
+	if p.sassTempDir != "" {
+		if err := os.RemoveAll(p.sassTempDir); err != nil {
+			return err
+		}
+		p.sassTempDir = ""
+	}
 	if err := p.makeSASSTempDir(); err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -77,7 +77,7 @@ func (s *Server) handler(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Content-Type", mimeType)
 	}
 	var w io.Writer = rw
-	if strings.HasPrefix(mimeType, "text/html;") {
+	if strings.HasPrefix(mimeType, "text/html;") && site.Config().Watch {
 		w = NewLiveReloadInjector(w)
 	}
 	err := site.WriteDocument(w, p)

--- a/site/write.go
+++ b/site/write.go
@@ -64,7 +64,10 @@ func (s *Site) WriteDoc(d Document) error {
 		log.Info("create %s from %s", to, d.Source())
 	}
 	if s.cfg.DryRun {
-		// FIXME render the page, just don't write it
+		// Render non-static documents to catch errors, but don't write anything
+		if !d.IsStatic() {
+			return s.WriteDocument(io.Discard, d)
+		}
 		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(to), 0755); err != nil {


### PR DESCRIPTION
1. server/watcher: Refresh site pointer each iteration to prevent stale
   references after config/data/layout changes trigger full reload. The
   goroutine now acquires the current site with lock protection instead
   of capturing it once at startup.

2. site/write: Render documents during dry-run to catch template/Sass
   errors. Previously --dry-run skipped rendering entirely, defeating
   its purpose. Now non-static documents render to io.Discard.

3. renderers/sass: Clean temp directory before copying partials to
   remove stale files. Deleted or renamed partials previously lingered
   in the temp dir, causing incorrect CSS compilation.

4. server/server: Gate live-reload script injection on watch flag.
   Previously the script was injected even with --no-watch, causing
   spurious connection errors in browser console.