### PR TITLE
refactor: Replace log.Fatal with panic and fmt.Errorf for errors

### DIFF
--- a/renderers/markdown_test.go
+++ b/renderers/markdown_test.go
@@ -1,7 +1,6 @@
 package renderers
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +57,7 @@ func TestRenderMarkdownWithHtml2(t *testing.T) {
 func mustMarkdownString(md string) string {
 	s, err := renderMarkdown([]byte(md))
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	return string(s)
 }

--- a/site/drop.go
+++ b/site/drop.go
@@ -1,7 +1,7 @@
 package site
 
 import (
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/osteele/gojekyll/pages"
@@ -13,10 +13,11 @@ import (
 // ToLiquid returns the site variable for template evaluation.
 func (s *Site) ToLiquid() interface{} {
 	s.dropOnce.Do(func() {
-		if err := s.initializeDrop(); err != nil {
-			log.Fatalf("ToLiquid failed: %s\n", err)
-		}
+		s.dropErr = s.initializeDrop()
 	})
+	if s.dropErr != nil {
+		panic(fmt.Sprintf("site drop initialization failed: %s", s.dropErr))
+	}
 	return liquid.IterationKeyedMap(s.drop)
 }
 

--- a/site/site.go
+++ b/site/site.go
@@ -34,6 +34,7 @@ type Site struct {
 
 	drop     map[string]interface{} // cached drop value
 	dropOnce sync.Once
+	dropErr  error // error from initializeDrop, if any
 }
 
 // Document is in package pages.

--- a/site/theme.go
+++ b/site/theme.go
@@ -3,7 +3,6 @@ package site
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +14,7 @@ func (s *Site) findTheme() error {
 	}
 	exe, err := exec.LookPath("bundle")
 	if err != nil {
-		log.Fatal("bundle is not in your PATH", err)
+		return fmt.Errorf("bundle is not in your PATH: %w", err)
 	}
 	cmd := exec.Command(exe, "show", s.cfg.Theme)
 	cmd.Dir = s.AbsDir()

--- a/site/watch.go
+++ b/site/watch.go
@@ -2,7 +2,6 @@ package site
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -207,7 +206,7 @@ func (s *Site) makePollingWatcher() (<-chan string, error) {
 	}()
 	go func() {
 		if err := w.Start(time.Millisecond * 250); err != nil {
-			log.Fatal(err)
+			panic(fmt.Sprintf("file watcher failed to start: %s", err))
 		}
 	}()
 	return filenames, nil


### PR DESCRIPTION
This commit refactors error handling in several areas, replacing `log.Fatal` with `panic` or returning `fmt.Errorf` for better control flow and more specific error reporting.

- In `renderers/markdown_test.go`, `log.Fatal` within `mustMarkdownString` is replaced with `panic` to propagate errors during testing.
- In `site/drop.go`, initialization errors are now stored in `dropErr` and `panic` is used during `ToLiquid` if an error occurred, providing a clearer error message via `fmt.Sprintf`.
- In `site/theme.go`, the `log.Fatal` for a missing `bundle` executable is replaced with a `fmt.Errorf` to return the error gracefully.
- In `site/watch.go`, `log.Fatal` when the file watcher fails to start is replaced with `panic` and a descriptive message using `fmt.Sprintf`.