### PR TITLE
Implement #17 and #18 --baseurl and --config

### DIFF
--- a/commands/flags.go
+++ b/commands/flags.go
@@ -19,8 +19,13 @@ var (
 	_           = app.Flag("drafts", "Render posts in the _drafts folder").Short('D').Action(boolVar("drafts", &options.Drafts)).Bool()
 	_           = app.Flag("future", "Publishes posts with a future date").Action(boolVar("future", &options.Future)).Bool()
 	_           = app.Flag("unpublished", "Render posts that were marked as unpublished").Action(boolVar("unpublished", &options.Unpublished)).Bool()
+	_           = app.Flag("baseurl", "Serve the website from the given base URL").Action(stringVar("baseurl", &options.BaseURL)).String()
 	versionFlag = app.Flag("version", "Print the name and version").Short('v').Bool()
 )
+
+func init() {
+	app.Flag("config", "Custom configuration file").StringVar(&options.ConfigFile)
+}
 
 func init() {
 	app.HelpFlag.Short('h')

--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,20 @@ func (c *Config) FromDirectory(dir string) error {
 	return nil
 }
 
+// FromFile updates the config from a specific configuration file.
+func (c *Config) FromFile(path string) error {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err = Unmarshal(bytes, c); err != nil {
+		return utils.WrapPathError(err, path)
+	}
+	c.ConfigFile = path
+	// Note: Source directory is set by FromDirectory, not by the config file location
+	return nil
+}
+
 type configCompat struct {
 	Gems []string
 }

--- a/site/read.go
+++ b/site/read.go
@@ -16,8 +16,16 @@ import (
 // FromDirectory reads the configuration file, if it exists.
 func FromDirectory(dir string, flags config.Flags) (*Site, error) {
 	s := New(flags)
-	if err := s.cfg.FromDirectory(dir); err != nil {
-		return nil, utils.WrapError(err, "reading site")
+	if flags.ConfigFile != "" {
+		if err := s.cfg.FromFile(flags.ConfigFile); err != nil {
+			return nil, utils.WrapError(err, "reading site")
+		}
+		// Set source directory explicitly when using custom config
+		s.cfg.Source = dir
+	} else {
+		if err := s.cfg.FromDirectory(dir); err != nil {
+			return nil, utils.WrapError(err, "reading site")
+		}
 	}
 	s.cfg.ApplyFlags(s.flags)
 	return s, nil


### PR DESCRIPTION
This commit implements two feature-parity flags to match Jekyll's CLI:

- --baseurl: allows overriding the site's base URL from the command line
- --config: allows specifying a custom configuration file path

Changes:
- Added BaseURL and ConfigFile fields to config.Flags struct
- Registered --baseurl and --config flags in commands/flags.go
- Created Config.FromFile() method to load config from custom paths
- Updated ApplyFlags to sync flag values with liquid template variables
- Ensured proper source directory handling when using custom config

The --baseurl flag properly overrides the config file value and is available to liquid templates. The --config flag allows loading configuration from any file path while preserving the source directory from --source or the current working directory.

Fixes #17
Fixes #18