### PR TITLE
feat: Implement sassify filter for indented Sass syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Missing features:
 - Pagination
 - Math
 - Plugin system. ([Some individual plugins](./docs/plugins.md) are emulated.)
-- Liquid filter `sassify` is not implemented
 - Liquid is run in strict mode: undefined filters and variables are errors.
 - Missing markdown features:
   - [attribute lists](https://kramdown.gettalong.org/syntax.html#attribute-list-definitions)

--- a/filters/filters_test.go
+++ b/filters/filters_test.go
@@ -60,7 +60,7 @@ var filterTests = []struct{ in, expected string }{
 	{`{{ "The _config.yml file" | slugify: 'default' }}`, "the-config-yml-file"},
 	{`{{ "The _config.yml file" | slugify: 'pretty' }}`, "the-_config.yml-file"},
 
-	// {`{{ "nav\n\tmargin: 0" | sassify }}`, "nav {\n  margin: 0; }"},
+	{`{{ sass_code | sassify }}`, "nav {\n  margin: 0;\n}"},
 	{`{{ "nav {margin: 0}" | scssify }}`, "nav {\n  margin: 0;\n}"},
 
 	{`{{ "smartify single 'quotes' here" | smartify }}`, "smartify single ‘quotes’ here"},
@@ -86,6 +86,7 @@ var filterTestBindings = liquid.Bindings{
 	"page": map[string]interface{}{
 		"tags": []string{"Seattle", "Tacoma"},
 	},
+	"sass_code": "nav\n  margin: 0",
 	"site": map[string]interface{}{
 		"members": []map[string]interface{}{
 			{"name": "Alonzo", "graduation_year": 2013},


### PR DESCRIPTION
Adds support for the `sassify` Liquid filter to convert indented Sass syntax to CSS, complementing the existing `scssify` filter.

Implementation:
- Added sassifyFilter function using Dart Sass with SourceSyntaxSASS
- Reuses existing Sass transpiler singleton for efficiency
- Removed now-unused unimplementedFilter helper and logger import
- Added test case with proper indented Sass syntax
- Updated README to remove sassify from missing features list

Addresses #10