### PR TITLE
feat: Add math support with MathJax/KaTeX compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,32 @@ eval "$(gojekyll --completion-script-zsh)"
 This project works on the GitHub Pages sites that I and other contributors care
 about. It looks credible on a spot-check of other Jekyll sites.
 
+### Math Support
+
+gojekyll supports mathematical expressions using MathJax or KaTeX, compatible with Jekyll/kramdown syntax:
+
+- Use `$$...$$` delimiters for both inline and display math
+- Math expressions are preserved in the HTML output for client-side rendering
+- Works with both MathJax 3 and KaTeX
+
+**Example usage:**
+
+```markdown
+Inline math: The equation $$E=mc^2$$ is famous.
+
+Display math:
+$$
+\int_0^\infty e^{-x} dx = 1
+$$
+```
+
+**Setup:** Add MathJax or KaTeX scripts to your layout templates. See `example/_layouts/math.html` and `example/math-example.md` for complete examples.
+
 ### Current Limitations
 
 Missing features:
 
 - Pagination
-- Math
 - Plugin system. ([Some individual plugins](./docs/plugins.md) are emulated.)
 - Liquid is run in strict mode: undefined filters and variables are errors.
 - Missing markdown features:

--- a/example/_layouts/math.html
+++ b/example/_layouts/math.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title | default: site.title }}</title>
+
+    <!-- MathJax 3 Configuration -->
+    <script>
+    MathJax = {
+        tex: {
+            inlineMath: [['$$', '$$']],
+            displayMath: [['$$', '$$']],
+            processEscapes: true,
+            processEnvironments: true
+        },
+        options: {
+            skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+        }
+    };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" id="MathJax-script" async></script>
+
+    <!-- Alternative: KaTeX (uncomment to use instead of MathJax)
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/contrib/auto-render.min.js"
+        onload="renderMathInElement(document.body, {
+            delimiters: [
+                {left: '$$', right: '$$', display: true},
+                {left: '$$', right: '$$', display: false}
+            ],
+            throwOnError: false
+        });"></script>
+    -->
+
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        code {
+            background: #f4f4f4;
+            padding: 2px 6px;
+            border-radius: 3px;
+        }
+        pre {
+            background: #f4f4f4;
+            padding: 15px;
+            overflow-x: auto;
+            border-radius: 5px;
+        }
+    </style>
+</head>
+<body>
+    {{ content }}
+</body>
+</html>

--- a/example/math-example.md
+++ b/example/math-example.md
@@ -1,0 +1,67 @@
+---
+layout: math
+title: Math Rendering Example
+---
+
+# Math Rendering with gojekyll
+
+This page demonstrates mathematical expression rendering using MathJax or KaTeX.
+
+## Inline Math
+
+The famous equation $$E=mc^2$$ shows the relationship between energy and mass.
+
+Here's another example: $$x_0 = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
+
+## Display Math
+
+The Fundamental Theorem of Calculus:
+
+$$
+\int_a^b f'(x) dx = f(b) - f(a)
+$$
+
+Maxwell's Equations:
+
+$$
+\begin{aligned}
+\nabla \cdot \mathbf{E} &= \frac{\rho}{\epsilon_0} \\
+\nabla \cdot \mathbf{B} &= 0 \\
+\nabla \times \mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t} \\
+\nabla \times \mathbf{B} &= \mu_0\left(\mathbf{J} + \epsilon_0 \frac{\partial \mathbf{E}}{\partial t}\right)
+\end{aligned}
+$$
+
+## Matrices
+
+$$
+\begin{bmatrix}
+a & b \\
+c & d
+\end{bmatrix}
+\begin{bmatrix}
+x \\
+y
+\end{bmatrix}
+=
+\begin{bmatrix}
+ax + by \\
+cx + dy
+\end{bmatrix}
+$$
+
+## Complex Expression
+
+The probability density function of the normal distribution:
+
+$$
+f(x | \mu, \sigma^2) = \frac{1}{\sqrt{2\pi\sigma^2}} e^{-\frac{(x-\mu)^2}{2\sigma^2}}
+$$
+
+## Note
+
+Math expressions use the `$$...$$` delimiter for both inline and display math.
+- **Inline**: `$$E=mc^2$$` renders as $$E=mc^2$$
+- **Display**: Use `$$...$$` on its own lines for centered equations
+
+The delimiters are preserved in the HTML and rendered by MathJax or KaTeX on the client side.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/bep/godartsass/v2 v2.5.0
 	github.com/danog/blackfriday/v2 v2.1.6
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.1
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/jaschaephraim/lrserver v0.0.0-20240306232639-afed386b3640
 	github.com/k0kubun/pp v3.0.1+incompatible
@@ -20,6 +21,7 @@ require (
 	github.com/radovskyb/watcher v1.0.7
 	github.com/stretchr/testify v1.11.1
 	github.com/tdewolff/minify v2.3.6+incompatible
+	github.com/yuin/goldmark v1.7.13
 	golang.org/x/net v0.46.0
 	golang.org/x/oauth2 v0.30.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/firefart/nonamedreturns v1.0.6 h1:vmiBcKV/3EqKY3ZiPxCINmpS431OcE1S47AQUwhrg8E=
 github.com/firefart/nonamedreturns v1.0.6/go.mod h1:R8NisJnSIpvPWheCq0mNRXJok6D8h7fagJTF8EMEwCo=
-github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
-github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
@@ -239,6 +239,8 @@ github.com/godoc-lint/godoc-lint v0.10.1/go.mod h1:KleLcHu/CGSvkjUH2RvZyoK1MBC7p
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.1 h1:nUzXfRTszLliZuN0JTKeunXTRaiFX6ksaWP0puLLYAY=
+github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.3.1/go.mod h1:Wy8ThAA8p2/w1DY05vEzq6EIeI2mzDjvHsu7ULBVwog=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -664,6 +666,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 gitlab.com/bosi/decorder v0.4.2 h1:qbQaV3zgwnBZ4zPMhGLW4KZe7A7NwxEhJx39R3shffo=
 gitlab.com/bosi/decorder v0.4.2/go.mod h1:muuhHoaJkA9QLcYHq4Mj8FJUwDZ+EirSHRiaTcTf6T8=
 go-simpler.org/assert v0.9.0 h1:PfpmcSvL7yAnWyChSjOz6Sp6m9j5lyK8Ok9pEL31YkQ=

--- a/renderers/markdown_math_test.go
+++ b/renderers/markdown_math_test.go
@@ -1,0 +1,108 @@
+package renderers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMathDelimiters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string // what the output should contain
+	}{
+		{
+			name:     "Inline math with $$",
+			input:    "The equation $$E=mc^2$$ is famous.",
+			contains: "$$E=mc^2$$",
+		},
+		{
+			name: "Display math block",
+			input: `Some text
+
+$$
+\int_0^\infty e^{-x} dx = 1
+$$
+
+More text`,
+			contains: "$$",
+		},
+		{
+			name:     "Math with underscores",
+			input:    "The variable $$x_0$$ represents the initial value.",
+			contains: "$$x_0$$",
+		},
+		{
+			name:     "Math with asterisks",
+			input:    "The expression $$x * y$$ shows multiplication.",
+			contains: "$$x * y$$",
+		},
+		{
+			name: "Complex math expression",
+			input: `$$
+\begin{bmatrix}
+a & b \\
+c & d
+\end{bmatrix}
+$$`,
+			contains: "\\begin{bmatrix}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			html, err := renderMarkdown([]byte(tt.input))
+			require.NoError(t, err)
+			htmlStr := string(html)
+
+			// Verify that the math delimiters and content are preserved
+			require.Contains(t, htmlStr, tt.contains,
+				"Expected output to contain math expression")
+
+			// Verify math is NOT converted to HTML entities or modified
+			require.NotContains(t, htmlStr, "&lt;", "Math should not be HTML-escaped")
+			require.NotContains(t, htmlStr, "<em>", "Underscores in math should not create emphasis")
+		})
+	}
+}
+
+func TestMathWithMarkdown(t *testing.T) {
+	input := `# Header
+
+Some **bold** text and $$E=mc^2$$ inline math.
+
+$$
+F = ma
+$$
+
+More _italic_ text.`
+
+	html, err := renderMarkdown([]byte(input))
+	require.NoError(t, err)
+	htmlStr := string(html)
+
+	// Verify markdown is processed
+	require.Contains(t, htmlStr, "<strong>bold</strong>")
+	require.Contains(t, htmlStr, "<em>italic</em>")
+	require.Contains(t, htmlStr, "<h1")
+
+	// Verify math is preserved
+	require.Contains(t, htmlStr, "$$E=mc^2$$")
+	require.Contains(t, htmlStr, "$$")
+}
+
+func TestMathDelimitersNotInCodeBlocks(t *testing.T) {
+	input := "```\n$$E=mc^2$$\n```"
+
+	html, err := renderMarkdown([]byte(input))
+	require.NoError(t, err)
+	htmlStr := string(html)
+
+	// Math in code blocks should be treated as code, not math
+	require.Contains(t, htmlStr, "<code>")
+	// The $$ should be inside the code block, not treated as math passthrough
+	require.True(t, strings.Contains(htmlStr, "<code") && strings.Contains(htmlStr, "$$"),
+		"Code block should contain $$ as literal text")
+}


### PR DESCRIPTION
Implements #7 (client-side rendering)

Migrate from deprecated Blackfriday to Goldmark markdown processor with math delimiter preservation. Math expressions using $...$ delimiters are preserved in HTML output for client-side rendering with MathJax 3 or KaTeX.

This implements **client-side math rendering** (similar to GitHub Pages). Server-side rendering (kramdown-math-katex, kramdown-math-sskatex) will be tracked separately for full Jekyll compatibility.

Changes:
- Migrate renderers/markdown.go from Blackfriday to Goldmark
- Add hugo-goldmark-extensions/passthrough for math delimiter preservation
- Preserve $...$ delimiters for both inline and display math
- Update renderers/markdown_attrs.go for Goldmark compatibility
- Add comprehensive test suite in renderers/markdown_math_test.go
- Create example layout with MathJax 3 configuration
- Create example page with math usage demonstrations
- Update README.md with math support documentation

All existing markdown features maintained (GFM, footnotes, definition lists, typographer). Compatible with Jekyll's client-side approach (manual script injection in layouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)