### PR TITLE
fix: page.date should be undefined for non-posts

### DIFF
--- a/pages/drops.go
+++ b/pages/drops.go
@@ -47,7 +47,6 @@ func (p *page) ToLiquid() interface{} {
 	data := map[string]interface{}{
 		"categories":    p.Categories(),
 		"content":       p.maybeContent(),
-		"date":          fm.Get("date", p.modTime),
 		"excerpt":       p.Excerpt(),
 		"id":            utils.TrimExt(p.URL()),
 		"path":          siteRelPath,
@@ -58,6 +57,13 @@ func (p *page) ToLiquid() interface{} {
 
 		// de facto
 		"ext": ext,
+	}
+	// In Jekyll, page.date is only defined for posts and collection documents.
+	// For regular pages, it's only present if explicitly set in frontmatter.
+	if _, hasDate := fm["date"]; hasDate {
+		data["date"] = fm["date"]
+	} else if p.IsPost() {
+		data["date"] = p.modTime
 	}
 	for k, v := range p.fm {
 		switch k {


### PR DESCRIPTION
## Summary
- In Ruby Jekyll, `page.date` is only defined for posts (from filename or frontmatter). For regular pages without an explicit date, `page.date` is `nil`.
- Gojekyll was unconditionally setting `page.date` to the file's modification time for all pages, causing `{% if page.date %}` to always be truthy.
- Now `page.date` is only set when the page is a post or has an explicit date in frontmatter.

Fixes #115

## Test plan
- [x] All existing tests pass
- [ ] Verify `{% if page.date %}` returns false for regular pages without date in frontmatter
- [ ] Verify posts still have `page.date` set correctly