### PR TITLE
fix: prevent indented HTML from rendering as code blocks

### DIFF
--- a/renderers/markdown.go
+++ b/renderers/markdown.go
@@ -2,6 +2,7 @@ package renderers
 
 import (
 	"bytes"
+	"regexp"
 
 	"github.com/gohugoio/hugo-goldmark-extensions/passthrough"
 	"github.com/osteele/gojekyll/utils"
@@ -41,6 +42,47 @@ func createGoldmarkConverter() goldmark.Markdown {
 	)
 }
 
+// deIndentHTMLBlocks removes leading indentation from lines inside HTML blocks.
+// Kramdown doesn't treat 4-space indented content inside HTML blocks as code,
+// but CommonMark/Goldmark does. This preprocessor strips the indentation so
+// Goldmark renders the HTML correctly.
+//
+// An HTML block starts with a line beginning with an HTML block-level tag
+// (optionally preceded by up to 3 spaces) and ends at a blank line.
+var htmlBlockStartRE = regexp.MustCompile(`(?i)^\s{0,3}</?(?:address|article|aside|blockquote|details|dialog|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|header|hgroup|hr|li|main|nav|ol|p|pre|section|summary|table|ul)\b`)
+
+func deIndentHTMLBlocks(md []byte) []byte {
+	lines := bytes.Split(md, []byte("\n"))
+	result := make([][]byte, 0, len(lines))
+	inHTMLBlock := false
+
+	for _, line := range lines {
+		if !inHTMLBlock {
+			if htmlBlockStartRE.Match(line) {
+				inHTMLBlock = true
+			}
+		}
+		if inHTMLBlock {
+			if len(bytes.TrimSpace(line)) == 0 {
+				inHTMLBlock = false
+			} else {
+				// Remove up to 4 leading spaces from lines inside HTML blocks
+				trimmed := line
+				for i := 0; i < 4; i++ {
+					if len(trimmed) > 0 && trimmed[0] == ' ' {
+						trimmed = trimmed[1:]
+					} else {
+						break
+					}
+				}
+				line = trimmed
+			}
+		}
+		result = append(result, line)
+	}
+	return bytes.Join(result, []byte("\n"))
+}
+
 func renderMarkdown(md []byte) ([]byte, error) {
 	return renderMarkdownWithOptions(md, nil)
 }
@@ -66,6 +108,10 @@ func renderMarkdownWithOptions(md []byte, opts *TOCOptions) ([]byte, error) {
 		opts.MinLevel = 1
 		opts.MaxLevel = 6
 	}
+
+	// Preprocess: de-indent HTML blocks to prevent Goldmark from treating
+	// indented HTML as code blocks (kramdown compatibility)
+	md = deIndentHTMLBlocks(md)
 
 	// Create Goldmark converter and render markdown to HTML
 	converter := createGoldmarkConverter()

--- a/renderers/markdown_test.go
+++ b/renderers/markdown_test.go
@@ -54,6 +54,54 @@ func TestRenderMarkdownWithHtml2(t *testing.T) {
 	require.Contains(t, urlResult, "http://example.com")
 }
 
+func TestRenderMarkdownIndentedHTML(t *testing.T) {
+	// Regression test for issue #113: indented HTML inside HTML blocks
+	// should not be rendered as code blocks
+	input := "<ul>\n    <li class=\"post-item\">\n        <a href=\"/post1/\">Post 1</a>\n    </li>\n</ul>\n"
+	result := mustMarkdownString(input)
+	require.NotContains(t, result, "<pre>", "indented HTML should not become a code block")
+	require.NotContains(t, result, "<code>", "indented HTML should not become a code block")
+	require.Contains(t, result, "<li", "list items should be preserved")
+}
+
+func TestDeIndentHTMLBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, result string)
+	}{
+		{
+			name:  "indented HTML block",
+			input: "<ul>\n    <li>item</li>\n</ul>\n",
+			check: func(t *testing.T, result string) {
+				require.Contains(t, result, "<li>item</li>")
+				require.NotContains(t, result, "    <li>")
+			},
+		},
+		{
+			name:  "non-HTML content preserved",
+			input: "regular paragraph\n\n    indented code\n",
+			check: func(t *testing.T, result string) {
+				require.Contains(t, result, "    indented code")
+			},
+		},
+		{
+			name:  "HTML block ends at blank line",
+			input: "<div>\n    inside\n\n    outside\n",
+			check: func(t *testing.T, result string) {
+				require.Contains(t, result, "inside")
+				require.Contains(t, result, "    outside")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(deIndentHTMLBlocks([]byte(tt.input)))
+			tt.check(t, result)
+		})
+	}
+}
+
 func mustMarkdownString(md string) string {
 	s, err := renderMarkdown([]byte(md))
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes a regression introduced when switching from Blackfriday to Goldmark (#113)
- Kramdown doesn't treat 4-space indented content inside HTML blocks as code blocks, but CommonMark/Goldmark does
- Adds a preprocessor (`deIndentHTMLBlocks`) that strips leading indentation from lines inside HTML block-level elements before passing them to Goldmark
- This prevents properly formatted HTML (like indented `<li>` elements inside `<ul>`) from being wrapped in `<pre><code>` tags

Fixes #113

## Test plan
- [x] All existing tests pass
- [x] New regression test for indented HTML in HTML blocks
- [x] New unit tests for `deIndentHTMLBlocks` preprocessor
- [ ] Verify against reporter's test site: https://github.com/tekknolagi/gojekyll-bugs