### PR TITLE
feat: add build diagnostics for skipped files

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -25,6 +25,11 @@ func buildCommand(site *site.Site) error {
 	case err == nil:
 		elapsed := time.Since(commandStartTime)
 		bannerLog.label("", "wrote %d files in %.2fs.", count, elapsed.Seconds())
+		diag := site.Diagnostics()
+		diag.FilesOutput = count
+		if site.Config().Verbose || diag.FilesExcluded+diag.FilesStaticNoFM+diag.FilesUnpublished > 0 {
+			bannerLog.label("Diagnostics:", "%s", diag.DiagSummary())
+		}
 	case watch:
 		log.Error("%s", err.Error())
 	default:

--- a/site/read.go
+++ b/site/read.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osteele/gojekyll/collection"
 	"github.com/osteele/gojekyll/config"
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/gojekyll/pages"
 	"github.com/osteele/gojekyll/plugins"
 	"github.com/osteele/gojekyll/utils"
@@ -68,6 +69,7 @@ func (s *Site) Read() error {
 
 // readFiles scans the source directory and creates pages and collection.
 func (s *Site) readFiles(dir, base string) error {
+	log := logger.Default()
 	return filepath.Walk(dir, func(filename string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -79,14 +81,31 @@ func (s *Site) readFiles(dir, base string) error {
 		case info.IsDir():
 			return nil
 		case s.Exclude(rel):
+			s.diag.FilesFound++
+			s.diag.FilesExcluded++
+			if s.cfg.Verbose {
+				log.Info("skip (excluded): %s", rel)
+			}
 			return nil
 		case strings.HasPrefix(rel, "_"):
+			s.diag.FilesFound++
+			s.diag.FilesUnderscored++
+			if s.cfg.Verbose {
+				log.Info("skip (underscore): %s", rel)
+			}
 			return nil
 		}
+		s.diag.FilesFound++
 		defaultFrontmatter := s.cfg.GetFrontMatterDefaults("", rel)
 		d, err := pages.NewFile(s, filename, filepath.ToSlash(rel), defaultFrontmatter)
 		if err != nil {
 			return utils.WrapPathError(err, filename)
+		}
+		if d.IsStatic() {
+			s.diag.FilesStaticNoFM++
+			if s.cfg.Verbose {
+				log.Info("skip (no frontmatter → static file): %s", rel)
+			}
 		}
 		s.AddDocument(d, true)
 		if p, ok := d.(Page); ok {
@@ -103,6 +122,12 @@ func (s *Site) AddDocument(d Document, output bool) {
 		s.docs = append(s.docs, d)
 		if output {
 			s.Routes[d.URL()] = d
+		}
+	} else {
+		s.diag.FilesUnpublished++
+		if s.cfg.Verbose {
+			log := logger.Default()
+			log.Info("skip (unpublished): %s", d.Source())
 		}
 	}
 }

--- a/site/site.go
+++ b/site/site.go
@@ -1,6 +1,7 @@
 package site
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
@@ -35,6 +36,33 @@ type Site struct {
 	drop     map[string]interface{} // cached drop value
 	dropOnce sync.Once
 	dropErr  error // error from initializeDrop, if any
+
+	// Build diagnostics
+	diag BuildDiagnostics
+}
+
+// BuildDiagnostics tracks statistics about files processed during a build.
+type BuildDiagnostics struct {
+	FilesFound       int // total files walked
+	FilesExcluded    int // excluded by config
+	FilesUnderscored int // skipped due to leading underscore
+	FilesStaticNoFM  int // became static files (no frontmatter, requires frontmatter)
+	FilesUnpublished int // skipped due to published: false
+	FilesOutput      int // files actually written
+}
+
+// DiagSummary returns a human-readable summary of the build diagnostics.
+func (d BuildDiagnostics) DiagSummary() string {
+	return fmt.Sprintf(
+		"%d files found, %d output (%d excluded, %d no frontmatter, %d unpublished, %d underscore-prefixed)",
+		d.FilesFound, d.FilesOutput,
+		d.FilesExcluded, d.FilesStaticNoFM, d.FilesUnpublished, d.FilesUnderscored,
+	)
+}
+
+// Diagnostics returns the build diagnostics for this site.
+func (s *Site) Diagnostics() BuildDiagnostics {
+	return s.diag
 }
 
 // Document is in package pages.


### PR DESCRIPTION
## Summary
- Adds build diagnostics that report why files were skipped during build
- A diagnostics summary line is printed whenever files are excluded, lack frontmatter, or are unpublished
- In verbose mode (`-V`), individual skipped files are logged with the reason (excluded, no frontmatter, unpublished, underscore-prefixed)
- Helps users understand when gojekyll produces fewer output files than expected

Addresses #114

## Changes
- `site/site.go`: Added `BuildDiagnostics` struct to track skip reasons
- `site/read.go`: Updated `readFiles` and `AddDocument` to count and log skipped files
- `commands/build.go`: Print diagnostics summary after build

## Example output
```
  Diagnostics: 30521 files found, 502 output (127 excluded, 29892 no frontmatter, 0 unpublished, 0 underscore-prefixed)
```

## Test plan
- [x] All existing tests pass
- [ ] Test with reporter's large site to verify diagnostics output
- [ ] Test with `-V` flag to verify verbose per-file logging