### PR TITLE
chore: update supported Go versions to 1.25 and 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        go-version: ['1.25.x', '1.26.x']
     runs-on: ${{ matrix.os }}
+    name: test (${{ matrix.os }}, go ${{ matrix.go-version }})
 
     steps:
     - name: Checkout
@@ -20,7 +22,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.x'
+        go-version: ${{ matrix.go-version }}
         cache: true
 
     - name: Install Dart Sass
@@ -55,7 +57,7 @@ jobs:
   #   - name: Install Go
   #     uses: actions/setup-go@v5
   #     with:
-  #       go-version: '1.24.x'
+  #       go-version: '1.25.x'
   #
   #   - name: Check formatting
   #     run: |
@@ -79,7 +81,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.x'
+        go-version: '1.25.x'
 
     - name: Check go.mod and go.sum
       run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           # Cache disabled because golangci-lint-action has its own caching
           cache: false
       - name: golangci-lint

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.x'
+        go-version: '1.25.x'
         cache: true
 
     - name: Install Dart Sass

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/osteele/gojekyll
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.3
+toolchain go1.25.6
 
 require (
 	github.com/alecthomas/chroma v0.10.0


### PR DESCRIPTION
## Summary
- Update minimum Go version from 1.24 to 1.25 in go.mod
- Update CI workflows to test against Go 1.25.x and 1.26.x
- Add Go version matrix to the test job so both versions are tested on each OS

## Test plan
- [x] All tests pass locally with Go 1.25.6
- [ ] CI validates both Go 1.25.x and 1.26.x