### PR TITLE
fix: use filename slug for permalink :title instead of frontmatter title

### DIFF
--- a/pages/permalinks.go
+++ b/pages/permalinks.go
@@ -66,7 +66,7 @@ func (p *page) permalinkVariables() map[string]string {
 		"name":       utils.Slugify(name),
 		"path":       "/" + root, // TODO are we removing and then adding this?
 		"slug":       slug,
-		"title":      utils.Slugify(p.fm.String("title", name)),
+		"title":      slug,
 		"y_day":      strconv.Itoa(p.modTime.YearDay()),
 		// Undocumented but evident:
 		"output_ext": p.OutputExt(),

--- a/pages/permalinks_test.go
+++ b/pages/permalinks_test.go
@@ -217,13 +217,16 @@ func TestExpandPermalinkPattern(t *testing.T) {
 }
 
 func TestPostPermalinkPatterns(t *testing.T) {
-	// Test that posts correctly use date and category placeholders
+	// Test that posts correctly use date and category placeholders.
+	// In real usage, collection.parseFilename sets "slug" from the filename title
+	// (stripping the date prefix). We simulate that here.
 	var (
 		s = siteFake{t, config.Default()}
 		d = map[string]interface{}{
 			"categories": "blog tech",
 			"collection": "posts", // Mark as post
 			"title":      "My Post",
+			"slug":       "my-post", // Set by parseFilename from filename "2006-02-03-my-post"
 		}
 	)
 
@@ -296,27 +299,28 @@ func TestPagePermalinkEdgeCases(t *testing.T) {
 		expected string
 	}{
 		// Complex patterns with multiple placeholders
-		{"complex with categories", "/:categories/:year/:month/:day/:title/", "/test.md", "/test-page/"},
+		// Note: :title uses the filename slug, not the frontmatter title
+		{"complex with categories", "/:categories/:year/:month/:day/:title/", "/test.md", "/test/"},
 		{"categories at end", "/blog/:categories", "/test.md", "/blog"},
-		{"categories in middle", "/prefix/:categories/suffix/:title", "/test.md", "/prefix/suffix/test-page"},
+		{"categories in middle", "/prefix/:categories/suffix/:title", "/test.md", "/prefix/suffix/test"},
 
 		// Date placeholders in various positions
-		{"year only", "/:year/:title", "/test.md", "/test-page"},
-		{"date at end", "/blog/:title/:year/:month/:day", "/test.md", "/blog/test-page"},
-		{"mixed dates", "/:i_month/:short_year/:title/:y_day", "/test.md", "/test-page"},
+		{"year only", "/:year/:title", "/test.md", "/test"},
+		{"date at end", "/blog/:title/:year/:month/:day", "/test.md", "/blog/test"},
+		{"mixed dates", "/:i_month/:short_year/:title/:y_day", "/test.md", "/test"},
 
 		// Edge cases for cleanup
-		{"multiple slashes", "/:categories//:year///:title", "/test.md", "/test-page"},
-		{"trailing dates", "/blog/:title/:year/", "/test.md", "/blog/test-page"},
+		{"multiple slashes", "/:categories//:year///:title", "/test.md", "/test"},
+		{"trailing dates", "/blog/:title/:year/", "/test.md", "/blog/test"},
 
 		// Patterns that become empty or minimal
-		{"only categories", ":categories", "/test.md", "/test-page"},
-		{"only dates", ":year/:month/:day", "/test.md", "/test-page"},
-		{"dates and categories", ":categories/:year/:month/:day", "/test.md", "/test-page"},
+		{"only categories", ":categories", "/test.md", "/test"},
+		{"only dates", ":year/:month/:day", "/test.md", "/test"},
+		{"dates and categories", ":categories/:year/:month/:day", "/test.md", "/test"},
 
 		// Edge case specifically mentioned in PR review
 		{"categories with colon after", ":categories:slug", "/test.md", "/test"},
-		{"categories with multiple colons", "/prefix:categories:year:title", "/test.md", "/prefixtest-page"},
+		{"categories with multiple colons", "/prefix:categories:year:title", "/test.md", "/prefixtest"},
 	}
 
 	for _, test := range tests {
@@ -345,7 +349,7 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			globalPermalink: "pretty",
 			pagePath:        "/bread.html",
 			frontMatter:     map[string]interface{}{"title": "Bread Page"},
-			expected:        "/bread-page/", // Jekyll ignores dates/categories for pages
+			expected:        "/bread/", // :title uses filename slug, not frontmatter title
 		},
 		{
 			name:            "date permalink for regular page",
@@ -365,15 +369,15 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			name:            "pretty permalink for post",
 			globalPermalink: "pretty",
 			pagePath:        "/_posts/2006-02-03-hello.html",
-			frontMatter:     map[string]interface{}{"title": "Hello World", "collection": "posts"},
-			expected:        fmt.Sprintf("/%04d/%02d/%02d/hello-world/", localDate.Year(), localDate.Month(), localDate.Day()),
+			frontMatter:     map[string]interface{}{"title": "Hello World", "collection": "posts", "slug": "hello"},
+			expected:        fmt.Sprintf("/%04d/%02d/%02d/hello/", localDate.Year(), localDate.Month(), localDate.Day()),
 		},
 		{
 			name:            "date permalink for post",
 			globalPermalink: "date",
 			pagePath:        "/_posts/2006-02-03-hello.html",
-			frontMatter:     map[string]interface{}{"title": "Hello World", "collection": "posts"},
-			expected:        fmt.Sprintf("/%04d/%02d/%02d/hello-world.html", localDate.Year(), localDate.Month(), localDate.Day()),
+			frontMatter:     map[string]interface{}{"title": "Hello World", "collection": "posts", "slug": "hello"},
+			expected:        fmt.Sprintf("/%04d/%02d/%02d/hello.html", localDate.Year(), localDate.Month(), localDate.Day()),
 		},
 		{
 			name:            "front matter overrides global",
@@ -394,7 +398,7 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			globalPermalink: "pretty",
 			pagePath:        "/_authors/john.html",
 			frontMatter:     map[string]interface{}{"title": "John Doe", "collection": "authors"},
-			expected:        "/john-doe/", // Date/categories ignored for non-post collections
+			expected:        "/john/", // :title uses filename slug, not frontmatter title
 		},
 		// Issue #81: Custom global patterns should NOT apply to pages
 		{
@@ -436,7 +440,7 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			name:            "custom pattern with categories for post (issue #81)",
 			globalPermalink: "/:categories/:title/",
 			pagePath:        "/_posts/2006-02-03-news.html",
-			frontMatter:     map[string]interface{}{"title": "News", "categories": "tech announcements", "collection": "posts"},
+			frontMatter:     map[string]interface{}{"title": "News", "categories": "tech announcements", "collection": "posts", "slug": "news"},
 			expected:        "/announcements/tech/news/", // Posts use custom patterns with categories
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes the core issue in #114 where gojekyll produced far fewer output files than Ruby Jekyll.

The `:title` permalink placeholder was using the slugified frontmatter `title` instead of the filename-derived slug. This caused incorrect URLs for posts with non-ASCII titles, particularly sites with Chinese (汉字) content where slugification strips all non-ASCII characters.

## Example

For a post `2025-06-24-a-bug-in-buddhism.md` with frontmatter title `佛教的一个Bug（缺陷）...`:

| | Before | After | Ruby Jekyll |
|---|---|---|---|
| **URL** | `/bug/` | `/a-bug-in-buddhism/` | `/a-bug-in-buddhism/` |

## Impact

Tested against the reporter's site (https://github.com/yuqianyi1001/yuqianyi1001.github.io):

| | Ruby Jekyll | Gojekyll (before) | Gojekyll (after) |
|---|---|---|---|
| **Output files** | 756 | 544 | 753 |

The remaining 3-file difference is due to minor issues (case sensitivity in slugs, `.css.map` generation, `redirects.json` from jekyll-redirect-from).

## 修复说明

永久链接的 `:title` 占位符现在使用文件名派生的 slug，而不是 frontmatter 标题的 slug。这与 Ruby Jekyll 的行为一致，解决了中文标题帖子生成错误 URL 的问题。

## Test plan

- [x] Updated permalink tests to match Jekyll behavior (`:title` = filename slug)
- [x] All existing tests pass
- [x] Verified against Ruby Jekyll with Chinese-titled test post
- [x] Verified against reporter's 30k-file site: output count matches within 3 files

Fixes #114