### PR TITLE
fix: Unicode slugs, case preservation, and page permalinks

### DIFF
--- a/collection/strategies.go
+++ b/collection/strategies.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/osteele/gojekyll/config"
@@ -39,7 +40,10 @@ func (s postsStrategy) parseFilename(filename string, fm map[string]interface{})
 	if t, title, found := utils.ParseFilenameDateTitle(filename); found {
 		fm["date"] = t
 		fm["title"] = title
-		fm["slug"] = utils.Slugify(title)
+		// Use the raw filename portion after the date prefix as the slug,
+		// preserving Unicode characters and case (matching Ruby Jekyll)
+		base := utils.TrimExt(filepath.Base(filename))
+		fm["slug"] = base[len("2006-01-02-"):]
 	}
 }
 

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -101,8 +101,8 @@ func AddJekyllFilters(e *liquid.Engine, c *config.Config) {
 		}
 		p := map[string]string{
 			"raw":     `\s+`,
-			"default": `[^[:alnum:]]+`,
-			"pretty":  `[^[:alnum:]\._~!$&'()+,;=@]+`,
+			"default": `[^\p{L}\p{N}]+`,
+			"pretty":  `[^\p{L}\p{N}\._~!$&'()+,;=@]+`,
 		}[mode]
 		if p != "" {
 			s = regexp.MustCompile(p).ReplaceAllString(s, "-")

--- a/pages/permalinks.go
+++ b/pages/permalinks.go
@@ -45,9 +45,7 @@ func (p *page) permalinkVariables() map[string]string {
 		relpath = p.relPath
 		root    = utils.TrimExt(relpath)
 		name    = filepath.Base(root)
-		slug    = p.fm.String("slug", utils.Slugify(name))
-		// date      = p.fileModTime
-		// date = p.PostDate().In(time.Local)
+		slug    = p.fm.String("slug", utils.SlugifyPermalink(name))
 	)
 	loc := time.Local
 	if tzName := p.site.Config().PermalinkTimezone; tzName != "" {
@@ -63,7 +61,7 @@ func (p *page) permalinkVariables() map[string]string {
 	vars := map[string]string{
 		"categories": strings.Join(p.Categories(), "/"),
 		"collection": p.fm.String("collection", ""),
-		"name":       utils.Slugify(name),
+		"name":       utils.SlugifyPermalink(name),
 		"path":       "/" + root, // TODO are we removing and then adding this?
 		"slug":       slug,
 		"title":      slug,
@@ -82,54 +80,22 @@ func (p *page) computePermalink(vars map[string]string) (src string, err error) 
 	var pattern string
 	if permalink, hasFrontMatterPermalink := p.fm["permalink"]; hasFrontMatterPermalink {
 		pattern = fmt.Sprintf("%v", permalink)
+	} else if globalPermalink := p.site.Config().Permalink; globalPermalink != "" {
+		pattern = globalPermalink
 	} else {
-		// If no front matter permalink, check global config
-		if globalPermalink := p.site.Config().Permalink; globalPermalink != "" {
-			// For non-posts (pages and collections), only apply built-in permalink styles
-			// Custom patterns should only affect posts
-			if !p.IsPost() {
-				if _, isBuiltInStyle := PermalinkStyles[globalPermalink]; !isBuiltInStyle {
-					// Not a built-in style, use default pattern for pages
-					pattern = DefaultPermalinkPattern
-				} else {
-					// Built-in style, apply it
-					pattern = globalPermalink
-				}
-			} else {
-				// Posts use the global permalink regardless of whether it's built-in or custom
-				pattern = globalPermalink
-			}
-		} else {
-			pattern = DefaultPermalinkPattern
-		}
+		pattern = DefaultPermalinkPattern
 	}
 
-	// Check if pattern is a built-in style
-	isBuiltInStyle := false
+	// Expand built-in style names
 	if pat, found := PermalinkStyles[pattern]; found {
 		pattern = pat
-		isBuiltInStyle = true
 	}
 
-	// Jekyll Compatibility: Custom patterns (non-built-in styles) should only
-	// apply to posts when set globally. Pages and other collections should use
-	// the default pattern when a custom pattern is configured globally.
-	//
-	// However, custom patterns explicitly set in a page's front matter should
-	// still be honored (with date/category placeholders removed).
-	//
-	// Built-in styles (pretty, date, ordinal, none) apply to all document types,
-	// but date/category placeholders are removed for non-posts.
+	// For non-posts, strip date and category placeholders from the pattern.
+	// This matches Ruby Jekyll: custom patterns like /:title/ apply to pages,
+	// but date/category placeholders are simply removed.
 	if !p.IsPost() {
-		_, hasFrontMatterPermalink := p.fm["permalink"]
-
-		if !isBuiltInStyle && !hasFrontMatterPermalink {
-			// Custom global patterns don't apply to pages - use default pattern
-			pattern = DefaultPermalinkPattern
-		} else {
-			// Built-in styles or explicit front matter permalinks: remove date/category placeholders
-			pattern = removePostOnlyPlaceholders(pattern)
-		}
+		pattern = removePostOnlyPlaceholders(pattern)
 	}
 
 	templateVariables := p.permalinkVariables()

--- a/pages/permalinks_test.go
+++ b/pages/permalinks_test.go
@@ -400,13 +400,14 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			frontMatter:     map[string]interface{}{"title": "John Doe", "collection": "authors"},
 			expected:        "/john/", // :title uses filename slug, not frontmatter title
 		},
-		// Issue #81: Custom global patterns should NOT apply to pages
+		// Issue #81 / #124: Custom global patterns now apply to pages too,
+		// with date/category placeholders stripped (matching Ruby Jekyll)
 		{
-			name:            "custom pattern /blog/:slug/ for page (issue #81)",
+			name:            "custom pattern /blog/:slug/ for page (issue #81/#124)",
 			globalPermalink: "/blog/:slug/",
 			pagePath:        "/about.html",
 			frontMatter:     map[string]interface{}{"title": "About"},
-			expected:        "/about.html", // Pages ignore custom global patterns
+			expected:        "/blog/about/",
 		},
 		{
 			name:            "custom pattern /blog/:slug/ for post (issue #81)",
@@ -416,11 +417,11 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			expected:        "/blog/2006-02-03-hello-world/", // Posts use custom global patterns (slug is from filename)
 		},
 		{
-			name:            "custom pattern /:year/:month/:slug/ for page (issue #81)",
+			name:            "custom pattern /:year/:month/:slug/ for page (issue #81/#124)",
 			globalPermalink: "/:year/:month/:slug/",
 			pagePath:        "/contact.html",
 			frontMatter:     map[string]interface{}{"title": "Contact"},
-			expected:        "/contact.html", // Pages ignore custom global patterns
+			expected:        "/contact/", // Date placeholders stripped, :slug preserved
 		},
 		{
 			name:            "custom pattern /:year/:month/:slug/ for post (issue #81)",
@@ -430,11 +431,11 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			expected:        fmt.Sprintf("/%04d/%02d/2006-02-03-test-post/", localDate.Year(), localDate.Month()), // Posts use custom patterns with dates
 		},
 		{
-			name:            "custom pattern with categories for page (issue #81)",
+			name:            "custom pattern with categories for page (issue #81/#124)",
 			globalPermalink: "/:categories/:title/",
 			pagePath:        "/services.html",
 			frontMatter:     map[string]interface{}{"title": "Services", "categories": "web design"},
-			expected:        "/services.html", // Pages ignore custom global patterns
+			expected:        "/services/", // Categories stripped, :title preserved
 		},
 		{
 			name:            "custom pattern with categories for post (issue #81)",
@@ -444,11 +445,11 @@ func TestGlobalPermalinkConfiguration(t *testing.T) {
 			expected:        "/announcements/tech/news/", // Posts use custom patterns with categories
 		},
 		{
-			name:            "custom pattern with :path for page (issue #81)",
+			name:            "custom pattern with :path for page (issue #81/#124)",
 			globalPermalink: "/custom/:path/",
 			pagePath:        "/about.html",
 			frontMatter:     map[string]interface{}{},
-			expected:        "/about.html", // Custom patterns don't apply to pages
+			expected:        "/custom/about/", // Custom patterns apply to pages
 		},
 	}
 

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -42,14 +42,24 @@ func SafeReplaceAllStringFunc(re *regexp.Regexp, src string, repl func(m string)
 	}), nil
 }
 
-var nonAlphanumericSequenceMatcher = regexp.MustCompile(`[^[:alnum:]]+`)
+var nonAlphanumericSequenceMatcher = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 var leadingOrTrailingHyphenMatcher = regexp.MustCompile(`(^-|-$)`)
 
-// Slugify replaces each sequence of non-alphanumerics by a single hyphen
+// Slugify replaces each sequence of non-alphanumerics by a single hyphen,
+// and lowercases the result. This matches the Liquid `slugify` filter behavior.
 func Slugify(s string) string {
 	slug := strings.ToLower(nonAlphanumericSequenceMatcher.ReplaceAllString(s, "-"))
 
 	// remove leading and trailing hyphen
+	slug = leadingOrTrailingHyphenMatcher.ReplaceAllString(slug, "")
+	return slug
+}
+
+// SlugifyPermalink replaces each sequence of non-alphanumerics by a single hyphen,
+// but preserves the original case. Used for permalink :title and :name variables
+// to match Ruby Jekyll's behavior.
+func SlugifyPermalink(s string) string {
+	slug := nonAlphanumericSequenceMatcher.ReplaceAllString(s, "-")
 	slug = leadingOrTrailingHyphenMatcher.ReplaceAllString(slug, "")
 	return slug
 }

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -36,6 +36,36 @@ func TestSlugify(t *testing.T) {
 	require.Equal(t, "ab-c", Slugify("ab()[]c"))
 	require.Equal(t, "ab123-cde-f-g", Slugify("ab123(cde)[]f.g"))
 	require.Equal(t, "abc", Slugify("abc?"))
+
+	// Unicode: Chinese characters preserved
+	require.Equal(t, "白法", Slugify("白法"))
+	require.Equal(t, "hello-白法-world", Slugify("hello 白法 world"))
+
+	// Unicode: accented characters preserved
+	require.Equal(t, "café", Slugify("café"))
+	require.Equal(t, "naïve-résumé", Slugify("naïve résumé"))
+
+	// Slugify lowercases
+	require.Equal(t, "hello-world", Slugify("Hello World"))
+}
+
+func TestSlugifyPermalink(t *testing.T) {
+	// Preserves case
+	require.Equal(t, "Hello-World", SlugifyPermalink("Hello World"))
+	require.Equal(t, "MyPage", SlugifyPermalink("MyPage"))
+
+	// Preserves Unicode
+	require.Equal(t, "白法", SlugifyPermalink("白法"))
+	require.Equal(t, "Hello-白法-World", SlugifyPermalink("Hello 白法 World"))
+	require.Equal(t, "Café", SlugifyPermalink("Café"))
+
+	// Replaces non-alphanumeric with hyphens
+	require.Equal(t, "ab-c", SlugifyPermalink("ab.c"))
+	require.Equal(t, "ab-c", SlugifyPermalink("ab()[]c"))
+
+	// Strips leading/trailing hyphens
+	require.Equal(t, "abc", SlugifyPermalink("abc?"))
+	require.Equal(t, "abc", SlugifyPermalink("?abc"))
 }
 
 func TestStringArrayToMap(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #122, #123, #124 — three residual differences found when comparing gojekyll output to Ruby Jekyll on a Chinese Buddhist studies site.

- **#122**: `Slugify` now uses Unicode-aware regex (`\p{L}\p{N}`) instead of ASCII-only `[:alnum:]`, preserving Chinese hanzi, accented letters, etc.
- **#123**: New `SlugifyPermalink` function preserves case for permalink `:title`, `:name`, and `:slug` variables. Post slugs are derived from the raw filename portion (not `Slugify(title)`).
- **#124**: Custom global permalink patterns (e.g., `/:title/`) now apply to non-post pages, with date/category placeholders stripped. This matches Ruby Jekyll behavior where `baifa.html` with `permalink: /:title/` outputs `/baifa/index.html`.

## Changed files

- `utils/strings.go` — Unicode regex fix, new `SlugifyPermalink`
- `filters/filters.go` — Unicode-aware Liquid `slugify` filter
- `collection/strategies.go` — Raw filename slug for posts
- `pages/permalinks.go` — `SlugifyPermalink` usage, simplified `computePermalink`
- `utils/strings_test.go` — Unicode and case-preservation tests
- `pages/permalinks_test.go` — Updated expectations for page permalink behavior

## Test plan

- [x] `go test ./...` passes
- [ ] CI passes
- [ ] Build and test against reporter's site to verify Chinese-titled posts and standalone pages