### PR TITLE
fix: handle HTML void elements in markdown attribute processing

### DIFF
--- a/renderers/markdown_attrs.go
+++ b/renderers/markdown_attrs.go
@@ -4,10 +4,33 @@ import (
 	"bytes"
 	"io"
 	"regexp"
+	"strings"
 
 	"github.com/osteele/gojekyll/utils"
 	"golang.org/x/net/html"
 )
+
+// HTML void elements that are self-closing and never have an end tag.
+// See https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+var htmlVoidElements = map[string]bool{
+	"area": true, "base": true, "br": true, "col": true,
+	"embed": true, "hr": true, "img": true, "input": true,
+	"link": true, "meta": true, "param": true, "source": true,
+	"track": true, "wbr": true,
+}
+
+// isVoidElement returns true if the raw token bytes represent a void element.
+func isVoidElement(raw []byte) bool {
+	s := strings.TrimLeft(string(raw), "< ")
+	// Extract tag name (up to space, /, or >)
+	for i, c := range s {
+		if c == ' ' || c == '/' || c == '>' || c == '\t' || c == '\n' {
+			s = s[:i]
+			break
+		}
+	}
+	return htmlVoidElements[strings.ToLower(s)]
+}
 
 var markdownAttrRE = regexp.MustCompile(`\s*markdown\s*=[^\s>]*\s*`)
 
@@ -107,12 +130,12 @@ loop:
 			if err == io.EOF {
 				return utils.WrapError(err,
 					"unexpected EOF while processing markdown attribute. "+
-						"Common causes: unclosed HTML tags (use <br/> instead of <br>), "+
+						"Common causes: unclosed HTML tags, "+
 						"or mismatched opening/closing tags")
 			}
 			return err
 		case html.StartTagToken:
-			if !notATagRE.Match(z.Raw()) {
+			if !notATagRE.Match(z.Raw()) && !isVoidElement(z.Raw()) {
 				depth++
 			}
 		case html.EndTagToken:
@@ -179,12 +202,12 @@ loop:
 			if err == io.EOF {
 				return utils.WrapError(err,
 					"unexpected EOF while processing markdown=\"0\" attribute. "+
-						"Common causes: unclosed HTML tags (use <br/> instead of <br>), "+
+						"Common causes: unclosed HTML tags, "+
 						"or mismatched opening/closing tags")
 			}
 			return err
 		case html.StartTagToken:
-			if !notATagRE.Match(z.Raw()) {
+			if !notATagRE.Match(z.Raw()) && !isVoidElement(z.Raw()) {
 				depth++
 			}
 		case html.EndTagToken:

--- a/renderers/markdown_test.go
+++ b/renderers/markdown_test.go
@@ -102,6 +102,30 @@ func TestDeIndentHTMLBlocks(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownVoidElements(t *testing.T) {
+	// Issue #66: <br> tags inside markdown="1" blocks should not cause EOF errors.
+	// Void elements like <br>, <hr>, <img> don't have end tags, so the depth
+	// tracker must not increment for them.
+
+	// These should not panic or error (the main fix for #66)
+	result := mustMarkdownString("\n<div markdown=\"1\">\n<br>\n<br>\n</div>\n")
+	require.Contains(t, result, "<br")
+
+	result = mustMarkdownString("\n<div markdown=\"1\">\n<hr>\n</div>\n")
+	require.Contains(t, result, "<hr")
+
+	result = mustMarkdownString("\n<div markdown=\"1\">\n<img src=\"test.png\">\n</div>\n")
+	require.Contains(t, result, "img")
+
+	// Self-closing variants should also work
+	result = mustMarkdownString("\n<div markdown=\"1\">\n<br/>\n</div>\n")
+	require.Contains(t, result, "<br")
+
+	// markdown="0" with void elements should also not error
+	result = mustMarkdownString("\n<div markdown=\"0\">\n<br>\n<br>\ntext\n</div>\n")
+	require.Contains(t, result, "text")
+}
+
 func mustMarkdownString(md string) string {
 	s, err := renderMarkdown([]byte(md))
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #66 — `<br>` tags (and other HTML void elements) inside `markdown="1"` blocks caused an "unexpected EOF" error.

**Root cause**: The HTML tokenizer depth tracker in `processInnerMarkdown` and `copyContent` incremented depth on every `StartTagToken`, but void elements (`<br>`, `<hr>`, `<img>`, etc.) never produce a matching `EndTagToken`. This caused the depth counter to never reach 0, resulting in EOF when the tokenizer ran out of input.

**Fix**: Skip depth increment for [HTML void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements). Both `<br>` (HTML5) and `<br/>` (XHTML) forms are handled correctly.

## Test plan

- [x] `go test ./...` passes
- [x] Added tests for `<br>`, `<hr>`, `<img>` inside `markdown="1"` and `markdown="0"` blocks
- [ ] CI passes