### PR TITLE
fix: handle missing git repo gracefully in github-metadata plugin

### DIFF
--- a/plugins/github_metadata.go
+++ b/plugins/github_metadata.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/osteele/gojekyll/config"
+	"github.com/osteele/gojekyll/logger"
 	"github.com/osteele/liquid"
 	"golang.org/x/oauth2"
 )
@@ -23,6 +24,7 @@ func init() {
 type jekyllGithubMetadataPlugin struct{ plugin }
 
 func (p jekyllGithubMetadataPlugin) ModifySiteDrop(s Site, d map[string]interface{}) error {
+	log := logger.Default()
 	var (
 		cfg        = s.Config()
 		isUserPage = false
@@ -30,11 +32,13 @@ func (p jekyllGithubMetadataPlugin) ModifySiteDrop(s Site, d map[string]interfac
 	)
 	nwo, err := getCurrentRepo(cfg)
 	if err != nil {
-		return err
+		log.Warn("jekyll-github-metadata: can't determine current repository: %s", err)
+		return nil
 	}
 	repo, err := getGitHubRepo(nwo)
 	if err != nil {
-		return err
+		log.Warn("jekyll-github-metadata: can't fetch repository %q from GitHub: %s", nwo, err)
+		return nil
 	}
 	if *repo.Name == fmt.Sprintf("%s.github.com", strings.ToLower(*repo.Owner.Login)) {
 		isUserPage = true


### PR DESCRIPTION
## Summary

- The `jekyll-github-metadata` plugin previously panicked when it couldn't determine the current repository (e.g. when the site source isn't a git repo, or has no GitHub remote)
- Now it logs a warning and continues the build without GitHub metadata, instead of crashing

## What changed

`plugins/github_metadata.go`: Both `getCurrentRepo` and `getGitHubRepo` errors are now caught, logged as warnings, and the plugin returns `nil` to allow the build to proceed.

## Repro

Before this fix, building a site that uses `github-pages` plugin from a non-git directory (e.g. a tarball download) caused a panic:

```
panic: site drop initialization failed: running plugin: exit status 128
```

After this fix:
```
jekyll-github-metadata: can't determine current repository: exit status 128
wrote 151 files in 1.06s.
```

## Test plan

- [x] `go test ./...` — all tests pass
- [x] Build sd17spring.github.io from tarball (no .git directory) — warns and builds 151 files
- [x] Existing sites with proper git remotes continue to work as before